### PR TITLE
Add edit button for editing docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -29,6 +29,7 @@ const siteConfig = {
     //{page: 'help', label: 'Help'},
   ],
   users,
+  editUrl: 'https://github.com/openebs/openebs-docs/edit/staging/docs/',
   /* path to images for header/footer */
   headerIcon: 'img/OpenEBSLogo.png',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
Add an edit button for editing docs from docs website only.

fixes : https://app.zenhub.com/workspace/o/mayadata-io/openebs-tracker/issues/71

Signed-off-by: sagar <sagar.kumar@openebs.io>