### PR TITLE
Add sidebars dropdown functionality to display sub-headings as dropdown items

### DIFF
--- a/website/node_modules/docusaurus/lib/core/nav/SideNav.js
+++ b/website/node_modules/docusaurus/lib/core/nav/SideNav.js
@@ -44,14 +44,33 @@ class SideNav extends React.Component {
         `,
           }}
         />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            var elem = document.getElementsByClassName("languages-menu");
+            for (var i=0; i < elem.length; i++){
+              document.getElementById(String(elem[i].id)).addEventListener("click", function() {
+                if ( document.getElementById(this.id+"dropdown-content-div").className == "hide") {
+                  document.getElementById(this.id+"dropdown-content-div").className = "visible";
+                }
+                else {
+                  document.getElementById(this.id+"dropdown-content-div").className = "hide";
+                }
+            })};`,
+          }}
+        />
       </nav>
     );
   }
   renderCategory(category) {
     return (
       <div className="navGroup navGroupActive" key={category.name}>
-        <h3>{this.getLocalizedCategoryString(category.name)}</h3>
-        <ul>{category.links.map(this.renderItemLink, this)}</ul>
+          <h3 id={category.name} className="languages-menu">
+            {this.getLocalizedCategoryString(category.name)}
+          </h3>
+          <div id = {category.name + "dropdown-content-div"} className="hide">
+            <ul id="languages-dropdown-items">{category.links.map(this.renderItemLink, this)}</ul>
+          </div>
       </div>
     );
   }

--- a/website/node_modules/docusaurus/lib/static/css/main.css
+++ b/website/node_modules/docusaurus/lib/static/css/main.css
@@ -1032,7 +1032,7 @@ pre code {
 }
 ul#languages-dropdown-items {
   display: flex;
-  background-color: $primaryColor;
+  background-color: #ffffff;
   flex-direction: column;
   min-width: 120px;
   pointer-events: all;
@@ -1953,4 +1953,12 @@ footer .copyright {
 .down {
   transform: rotate(45deg);
   -webkit-transform: rotate(45deg);
+}
+
+/** dropdown menu hide and visibility **/
+.visible {
+  display: flex;
+}
+.hide {
+  display: none;
 }


### PR DESCRIPTION
- This PR intends to add a dropdown functionality for sidebars so that the sub-headings or sidebars inside a header could be displayed as dropdown items
- This PR intends to shorten the length of sidebars by just displaying the main headings and sub-headings or sidebars as dropdown items.

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>