### PR TITLE
Enabling RBAC on Azure

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -126,9 +126,8 @@ Check the status of iSCSI service by running the following command inside kubele
 azureuser@aks-nodepool1-46849391-1:~$ service open-iscsi status
 ```
 
-**Note**:There might be the case where hyperkube kubelet is running as a binary in nodes.In such cases check 
-
-​           for open-iscsi status in node. If it is not present then follow below steps to install open-iscsi.
+If hyperkube kubelet is running as a binary in the nodes, check for open-iscsi status in the node. If
+open-iscsi is not present, follow the procedure below to install open-iscsi.
 
 ```
 azureuser@aks-nodepool1-46849391-1:~$ 
@@ -138,7 +137,9 @@ azureuser@aks-nodepool1-46849391-1:~$
 
 ### Configuring RBAC on Azure cloud
 
-On Azure cloud,you need to enable the clusterrole binding by applying the below yaml.
+On Azure cloud,
+
+you must enable the cluster role binding by applying the following yaml.
 
 ```
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -126,6 +126,41 @@ Check the status of iSCSI service by running the following command inside kubele
 azureuser@aks-nodepool1-46849391-1:~$ service open-iscsi status
 ```
 
+**Note**:There might be the case where hyperkube kubelet is running as a binary in nodes.In such cases check 
+
+​           for open-iscsi status in node. If it is not present then follow below steps to install open-iscsi.
+
+```
+azureuser@aks-nodepool1-46849391-1:~$ 
+# apt-get update
+# apt install -y open-iscsi
+```
+
+### Configuring RBAC on Azure cloud
+
+On Azure cloud,you need to enable the clusterrole binding by applying the below yaml.
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp:null
+  name: cluster-admin
+  annotations:
+   rbac.authorization.kubernetes.io/autoupdate: "true"
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+```
+
 
 
 <!-- Hotjar Tracking Code for https://docs.openebs.io -->

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -126,7 +126,7 @@ Check the status of iSCSI service by running the following command inside kubele
 azureuser@aks-nodepool1-46849391-1:~$ service open-iscsi status
 ```
 
-If hyperkube kubelet is running as a binary in the nodes, check for open-iscsi status in the node. If
+**Note:** If hyperkube kubelet is running as a binary in the nodes, check for open-iscsi status in the node. If
 open-iscsi is not present, follow the procedure below to install open-iscsi.
 
 ```
@@ -137,9 +137,7 @@ azureuser@aks-nodepool1-46849391-1:~$
 
 ### Configuring RBAC on Azure cloud
 
-On Azure cloud,
-
-you must enable the cluster role binding by applying the following yaml.
+On Azure cloud, you must enable the cluster role binding by applying the following yaml.
 
 ```
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Added the yaml that needed to be executed for enabling RBAC on Azure.
This will be useful when we try to install openebs through helm.
Signed-off-by: Prabhat kumar Thakur<prabhat.thakur@cloudbyte.com>