### PR TITLE
Add a copy button to code blocks to provide code copy functionality

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -45,7 +45,14 @@ const siteConfig = {
     // Highlight.js theme to use for syntax highlighting in code blocks
     theme: 'default',
   },
-  scripts: ['https://buttons.github.io/buttons.js'],
+  scripts: [
+    'https://buttons.github.io/buttons.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
+    '/js/code-blocks-buttons.js',
+  ],
+  stylesheets: [
+    '/css/code-blocks-buttons.css',
+  ],
 };
 
 module.exports = siteConfig;

--- a/website/static/css/code-blocks-buttons.css
+++ b/website/static/css/code-blocks-buttons.css
@@ -1,0 +1,41 @@
+/* "Copy" code block button */
+pre {
+  position: relative;
+}
+
+pre .btnIcon {
+  position: absolute;
+  top: 4px;
+  z-index: 2;
+  cursor: pointer;
+  border: 1px solid transparent;
+  color: #f1584d;
+  background-color: #f5f4f7;
+  height: 30px;
+  transition: all .25s ease-out;
+}
+
+pre .btnIcon:hover {
+  text-decoration: none;
+  background-color: #fff;
+}
+
+.btnIcon__body {
+  align-items: center;
+  display: flex;
+}
+
+.btnIcon svg {
+  fill: currentColor;
+  margin-right: .4em;
+}
+
+.btnIcon__label {
+  font-size: 11px;
+}
+
+.btnClipboard {
+  right: 1px;
+  border-radius: 4px;
+  padding: 0 8px;
+}

--- a/website/static/css/code-blocks-buttons.css
+++ b/website/static/css/code-blocks-buttons.css
@@ -9,7 +9,7 @@ pre .btnIcon {
   z-index: 2;
   cursor: pointer;
   border: 1px solid transparent;
-  color: #f1584d;
+  color: #383030;
   background-color: #f5f4f7;
   height: 30px;
   transition: all .25s ease-out;

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -191,8 +191,8 @@ img[alt$="<>"] {
     float: none!important;
 }
 
-pre code{
-    border-color: #f2a850;
+pre code {
+    border-color: #F0F0F0;
 }
 
 @media (max-width: 375px) {

--- a/website/static/js/code-blocks-buttons.js
+++ b/website/static/js/code-blocks-buttons.js
@@ -1,0 +1,48 @@
+/* global ClipboardJS */
+
+window.addEventListener('load', function() {
+  function button(label, ariaLabel, icon, className) {
+    const btn = document.createElement('button');
+    btn.classList.add('btnIcon', className);
+    btn.setAttribute('aria-label', ariaLabel);
+    btn.innerHTML =
+      '<div class="btnIcon__body">' +
+      icon +
+      '<strong class="btnIcon__label">' +
+      label +
+      '</strong>' +
+      '</div>' +
+      '</button>';
+    return btn;
+  }
+
+  function addButtons(codeBlockSelector, btn) {
+    document.querySelectorAll(codeBlockSelector).forEach(function(code) {
+      code.parentNode.appendChild(btn.cloneNode(true));
+    });
+  }
+
+  const copyIcon =
+    '<svg width="12" height="12" viewBox="340 364 14 15" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M342 375.974h4v.998h-4v-.998zm5-5.987h-5v.998h5v-.998zm2 2.994v-1.995l-3 2.993 3 2.994v-1.996h5v-1.995h-5zm-4.5-.997H342v.998h2.5v-.997zm-2.5 2.993h2.5v-.998H342v.998zm9 .998h1v1.996c-.016.28-.11.514-.297.702-.187.187-.422.28-.703.296h-10c-.547 0-1-.452-1-.998v-10.976c0-.546.453-.998 1-.998h3c0-1.107.89-1.996 2-1.996 1.11 0 2 .89 2 1.996h3c.547 0 1 .452 1 .998v4.99h-1v-2.995h-10v8.98h10v-1.996zm-9-7.983h8c0-.544-.453-.996-1-.996h-1c-.547 0-1-.453-1-.998 0-.546-.453-.998-1-.998-.547 0-1 .452-1 .998 0 .545-.453.998-1 .998h-1c-.547 0-1 .452-1 .997z" fill-rule="evenodd"/></svg>';
+
+  addButtons(
+    '.hljs',
+    button('Copy', 'Copy code to clipboard', copyIcon, 'btnClipboard')
+  );
+
+  const clipboard = new ClipboardJS('.btnClipboard', {
+    target: function(trigger) {
+      return trigger.parentNode.querySelector('code');
+    },
+  });
+
+  clipboard.on('success', function(event) {
+    event.clearSelection();
+    const textEl = event.trigger.querySelector('.btnIcon__label');
+    textEl.textContent = 'Copied';
+    setTimeout(function() {
+      textEl.textContent = 'Copy';
+    }, 2000);
+  });
+});
+


### PR DESCRIPTION
- This PR intends to add a copy button to all the code blocks so that a user can copy the code from there 
  using this copy button instead of typing the whole code.
- It will add a JS and CSS file which will enable the copy button for all the code blocks
- It will change the pre-code colour of the code blocks

fixes : #240 

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>