### PR TITLE
Add functionality to have H4 indented under H3

### DIFF
--- a/website/node_modules/docusaurus/lib/core/getTOC.js
+++ b/website/node_modules/docusaurus/lib/core/getTOC.js
@@ -18,16 +18,19 @@ const tagToLevel = tag => Number(tag.slice(1));
  * Array of heading objects with `hashLink`, `content` and `children` fields
  *
  */
-module.exports = (content, headingTags = 'h2', subHeadingTags = 'h3') => {
+module.exports = (content, headingTags = 'h2', subHeadingTags = 'h3', subSubHeadingTags='h4') => {
   const headingLevels = [].concat(headingTags).map(tagToLevel);
   const subHeadingLevels = subHeadingTags
     ? [].concat(subHeadingTags).map(tagToLevel)
+    : [];
+  const subSubHeadingLevels = subSubHeadingTags
+    ? [].concat(subSubHeadingTags).map(tagToLevel)
     : [];
 
   const md = new Remarkable();
   const headings = mdToc(content, {
     filter: function(str, ele) {
-      return headingLevels.concat(subHeadingLevels).includes(ele.lvl);
+      return headingLevels.concat(subHeadingLevels).concat(subSubHeadingLevels).includes(ele.lvl);
     },
   }).json;
 
@@ -35,6 +38,7 @@ module.exports = (content, headingTags = 'h2', subHeadingTags = 'h3') => {
   let current;
   headings.forEach(heading => {
     const entry = {
+      lvl: heading.lvl,
       hashLink: toSlug(heading.content),
       content: md.renderInline(mdToc.titleize(heading.content)),
       children: [],
@@ -50,3 +54,4 @@ module.exports = (content, headingTags = 'h2', subHeadingTags = 'h3') => {
 
   return toc;
 };
+

--- a/website/node_modules/docusaurus/lib/core/nav/OnPageNav.js
+++ b/website/node_modules/docusaurus/lib/core/nav/OnPageNav.js
@@ -23,25 +23,39 @@ const Headings = ({headings}) => {
   if (!headings.length) return null;
   return (
     <ul className="toc-headings">
-      {headings.map((heading, i) => (
-        <li key={i}>
-          <Link hashLink={heading.hashLink} content={heading.content} />
-          <Headings headings={heading.children} />
-        </li>
-      ))}
+    {headings.map(mapfunc)}
     </ul>
-  );
+    );
 };
+
+function mapfunc(heading, i){
+  if (heading.lvl == 4 || heading.lvl == 5) {
+    return (
+      <ul key={i} className="custom-list">
+        <Link hashLink={heading.hashLink} content={heading.content} />
+        <Headings headings={heading.children}/>
+      </ul>
+    );
+  }
+
+  return (
+    <li key={i}>
+        <Link hashLink={heading.hashLink} content={heading.content} />
+        <Headings headings={heading.children}/>
+      </li>
+  );
+}
 
 class OnPageNav extends React.Component {
   render() {
     const customTags = siteConfig.onPageNavHeadings;
+
     const headings = customTags
       ? getTOC(this.props.rawContent, customTags.topLevel, customTags.sub)
       : getTOC(this.props.rawContent);
-
     return <Headings headings={headings} />;
   }
 }
 
 module.exports = OnPageNav;
+

--- a/website/node_modules/docusaurus/lib/static/css/main.css
+++ b/website/node_modules/docusaurus/lib/static/css/main.css
@@ -110,6 +110,10 @@ blockquote {
   border-left: 5px solid rgba(191, 87, 73, 0.2);
 }
 
+.wrapper blockquote > p:first-child {
+  padding-top: 0;
+}
+
 #fb_oss a {
   border: 0;
 }
@@ -257,7 +261,7 @@ header h2 {
 .container .wrapper h4 {
   color: $primaryColor;
   font-size: 16px;
-  font-weight: 300;
+  font-weight: 450;
   margin: 0;
   padding: 10px 0 0;
 }
@@ -288,7 +292,7 @@ header h2 {
 .mainContainer .wrapper ul li,
 .mainContainer .wrapper ol li {
   line-height: 1.7;
-  max-width: 50rem;
+  max-width: 100%;
 }
 @media (max-width: 735px) {
   .mainContainer .wrapper p,
@@ -311,7 +315,7 @@ header h2 {
 .mainContainer .wrapper .post h1 {
   margin-top: 20px;
   margin-bottom: 0;
-  font-size: 250%;
+  font-size: 220%;
   padding: 10px 0;
 }
 .mainContainer .wrapper .post h2 {
@@ -382,7 +386,7 @@ header h2 {
 .mainContainer .wrapper .post h4,
 .mainContainer .wrapper .post h5,
 .mainContainer .wrapper .post h6 {
-  font-weight: 400;
+  font-weight: 450;
 }
 
 
@@ -449,10 +453,13 @@ header h2 {
   }
 
   .mainContainer .wrapper .post h2 {
-    font-size: 180%;
+    font-size: 190%;
   }
   .mainContainer .wrapper .post h3 {
-    font-size: 120%;
+    font-size: 150%;
+  }
+  .mainContainer .wrapper .post h4 {
+    font-size: 121%;
   }
   .mainContainer .wrapper .post .docPagination a .pagerLabel {
     display: none;
@@ -467,7 +474,7 @@ header h2 {
   }
   .homeContainer .homeWrapper #inner {
     box-sizing: border-box;
-    max-width: 600px;
+    max-width: 100%;
     padding-right: 40px;
   }
   .mainContainer .wrapper .post {
@@ -483,7 +490,7 @@ header h2 {
 }
 @media only screen and (min-width: 1200px) {
   .homeContainer .homeWrapper #inner {
-    max-width: 750px;
+    max-width: 100%;
   }
 
   .homeContainer .homeWrapper .projectLogo {
@@ -504,13 +511,13 @@ header h2 {
 }
 @media only screen and (min-width: 1500px) {
   .homeContainer .homeWrapper #inner {
-    max-width: 1100px;
+    max-width: 100%;
     padding-bottom: 40px;
     padding-top: 40px;
   }
 
   .wrapper {
-    max-width: 1400px;
+    max-width: 100%;
   }
 }
 .fixedHeaderContainer {
@@ -1506,7 +1513,7 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   @media only screen and (min-width: 1024px) {
     .separateOnPageNav.doc .wrapper,
     .separateOnPageNav .headerWrapper.wrapper {
-      max-width: 1400px;
+      max-width: 100%;
     }
 
     .doc.separateOnPageNav .docsNavContainer {
@@ -1558,6 +1565,10 @@ nav.toc .toggleNav .navBreadcrumb h2 {
 
     .onPageNav ul ul li {
       padding-bottom: 5px;
+    }
+
+    .custom-list {
+      margin-top: -7px;
     }
   }
 }
@@ -1961,4 +1972,27 @@ footer .copyright {
 }
 .hide {
   display: none;
+}
+
+/* CSS for aligning images in markdown */
+/* Use >, < or <> after the alt statement for images in markdown files to align
+images to right, left or center, such as
+![Installing OpenEBS using helm >](/docs/assets/helm.png) will align
+the image to right side of screen
+*/
+
+img[alt$=">"] {
+  float:right;
+}
+
+img[alt$="<"] {
+  float:left;
+}
+
+img[alt$="<>"] {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: auto;
+    float: none!important;
 }

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -56,8 +56,8 @@ body{
 .mainContainer .wrapper .post h1, .mainContainer .wrapper .post h2 {
     font-weight: 400;
 }
-.mainContainer .wrapper .post h3 {
-    font-weight: 450;
+.mainContainer .wrapper .post h3, .mainContainer .wrapper .post h3 {
+    font-weight: 400;
 }
 
 /* Body */	
@@ -68,7 +68,15 @@ body {
 h1, h2, h3, h4 {
     color: #282828;
 }
-
+.mainContainer .wrapper .post h2 {
+    font-size: 190%;
+}
+.mainContainer .wrapper .post h3 {
+    font-size: 155%;
+}
+.mainContainer .wrapper .post h4 {
+    font-size: 120%;
+}
 /* Css for image size */
 img {
   max-width: max-content;
@@ -173,24 +181,6 @@ nav.toc .toggleNav .navGroup.navGroupActive {
     margin-bottom: 0.5rem !important;
 }
 
-/* CSS for aligning images in markdown */
-
-img[alt$=">"] {
-  float:right;
-}
-
-img[alt$="<"] {
-  float:left;
-}
-
-img[alt$="<>"] {
-    display: block;
-    max-width: 100%;
-    height: auto;
-    margin: auto;
-    float: none!important;
-}
-
 pre code {
     border-color: #F0F0F0;
 }
@@ -272,7 +262,7 @@ and (max-device-width : 720px) {
     .ver-link {
       cursor: pointer;
       color: #fff;
-      margin-right: 130px;
+      margin-right: 150px;
       margin-top: 10px;
     }
 
@@ -280,8 +270,6 @@ and (max-device-width : 720px) {
       line-height: 1;
       font-size: 12px;
     }
-}
-
 }
 
 /**
@@ -299,3 +287,4 @@ and (max-device-width : 720px) {
 redoc .operation-type {
     display: none !important;
 }
+


### PR DESCRIPTION
This PR intends to modify/add these functionalities -

- Add a functionality to automatically indent H4 headings under H3 headings for OnPageNav on the doc right side.
- Add a functionality to adjust screens automatically for bigger screens i.e more than 1300*678
- Add font changes for H2, H3 and H4
- Add more padding to version dropdown

Changes committed:

	modified:   node_modules/docusaurus/lib/core/getTOC.js
	modified:   node_modules/docusaurus/lib/core/nav/OnPageNav.js
	modified:   node_modules/docusaurus/lib/static/css/main.css
	modified:   static/css/custom.css

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>