### PR TITLE
Fix OpenEBS-docs logo

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -32,7 +32,7 @@ const siteConfig = {
   onPageNav: 'separate',
   editUrl: 'https://github.com/openebs/openebs-docs/edit/staging/docs/',
   /* path to images for header/footer */
-  headerIcon: 'img/OpenEBSLogo.png',
+  headerIcon: 'img/openebs-logo.svg',
   favicon: 'img/favicon.ico',
   /* colors for website */
   colors: {


### PR DESCRIPTION
Current logo of OpenEBS docs is very small,
name of the image file is changed.

This commit updates the name in siteConfig.js

Signed-off-by: Akash Srivastava <akash.srivastava@openebs.io>