### PR TITLE
Add v0.7 dropdown to docs

### DIFF
--- a/website/node_modules/docusaurus/lib/core/nav/HeaderNav.js
+++ b/website/node_modules/docusaurus/lib/core/nav/HeaderNav.js
@@ -242,6 +242,7 @@ class HeaderNav extends React.Component {
                <div className="dropdown">
                  <p className="ver-link">v0.6 <i className="arrow down"></i></p>
                  <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                   <a className="dropdown-item" href="#">v0.7</a>
                    <a className="dropdown-item" href={this.props.baseUrl}>v0.6</a>
                    <a className="dropdown-item" href="https://v05-docs.openebs.io">v0.5</a>
                  </div>


### PR DESCRIPTION
This will add a v0.7 version dropdown to docs.
**Note** : The link to version v0.7 will be updated once v0.6 is mapped to ingress and staging is merged to master and a new branch v0.7 is checkout form master.

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>