### PR TITLE
Updated the readonlyvolume

### DIFF
--- a/docs/readonlyvolumes.md
+++ b/docs/readonlyvolumes.md
@@ -27,7 +27,9 @@ chown: changing ownership of '/var/lib/mysql/': Read-only file system
 
 ## How to recover from ReadOnly state ?	
 
-More details on the recovery steps are provided [here](https://docs.openebs.io/docs/next/tsgpvs.html#workaround-recovery). 
+OpenEBS jiva volumes, save the data in /var/openebs/pvc-id/.Ensure that all your replica pods are running on the same node where they were scheduled initially . After you verified, you can do the recovery steps. More details on the recovery steps are provided [here](https://docs.openebs.io/docs/next/tsgpvs.html#workaround-recovery). 
+
+If your are not pinned the replica volume to the k8s node where it got scheduled initially, then replicas could get scheduled onto a node where the data doesn't exist. In this case, you can do backup and recover data using the steps mentioned [here](https://github.com/kmova/bootstrap/tree/master/gke-openebs/jiva-recovery).
 
 ## Fixes in 0.6 release related to ReadOnly volumes
 

--- a/docs/readonlyvolumes.md
+++ b/docs/readonlyvolumes.md
@@ -27,9 +27,9 @@ chown: changing ownership of '/var/lib/mysql/': Read-only file system
 
 ## How to recover from ReadOnly state ?	
 
-Ensure that all your replica pods are running on the same node where they were scheduled initially . Once you verified, you can do the recovery steps. More details on the recovery steps are provided [here](https://docs.openebs.io/docs/next/tsgpvs.html#workaround-recovery). 
+Ensure that all your replica pods are running on the same node where they were scheduled initially . Once verified, you can perform the recovery steps. More details on the recovery steps are provided [here](https://docs.openebs.io/docs/next/tsgpvs.html#workaround-recovery). 
 
-If you are not pinned the replica volume to the k8s node where it got scheduled initially, then replicas could get scheduled onto a node where the data doesn't exist. In this case, you can do backup and recover data using the steps mentioned [here](https://github.com/kmova/bootstrap/tree/master/gke-openebs/jiva-recovery).
+If you have not pinned the replica volume to the k8s node where it was scheduled initially, the replicas could get scheduled onto a node where the data does not exist. In this case, you can backup and recover data using the steps mentioned [here](https://github.com/kmova/bootstrap/tree/master/gke-openebs/jiva-recovery).
 
 ## Fixes in 0.6 release related to ReadOnly volumes
 

--- a/docs/readonlyvolumes.md
+++ b/docs/readonlyvolumes.md
@@ -27,9 +27,9 @@ chown: changing ownership of '/var/lib/mysql/': Read-only file system
 
 ## How to recover from ReadOnly state ?	
 
-OpenEBS jiva volumes, save the data in /var/openebs/pvc-id/.Ensure that all your replica pods are running on the same node where they were scheduled initially . After you verified, you can do the recovery steps. More details on the recovery steps are provided [here](https://docs.openebs.io/docs/next/tsgpvs.html#workaround-recovery). 
+Ensure that all your replica pods are running on the same node where they were scheduled initially . Once you verified, you can do the recovery steps. More details on the recovery steps are provided [here](https://docs.openebs.io/docs/next/tsgpvs.html#workaround-recovery). 
 
-If your are not pinned the replica volume to the k8s node where it got scheduled initially, then replicas could get scheduled onto a node where the data doesn't exist. In this case, you can do backup and recover data using the steps mentioned [here](https://github.com/kmova/bootstrap/tree/master/gke-openebs/jiva-recovery).
+If you are not pinned the replica volume to the k8s node where it got scheduled initially, then replicas could get scheduled onto a node where the data doesn't exist. In this case, you can do backup and recover data using the steps mentioned [here](https://github.com/kmova/bootstrap/tree/master/gke-openebs/jiva-recovery).
 
 ## Fixes in 0.6 release related to ReadOnly volumes
 


### PR DESCRIPTION
Signed-off-by: ranjithwingrider ranjith.raveendran@openebe.io

Added a note about when replica got scheduled to a node where OpenEBS jiva volume data is not present.Given a link on how to do recovery of data in this case.
