### PR TITLE
fix(docs): Change accessMode value to array

### DIFF
--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -78,7 +78,7 @@ metadata:
     snapshot.alpha.kubernetes.io/snapshot: snapshot-demo
 spec:
   storageClassName: snapshot-promoter
-  accessModes: ReadWriteOnce
+  accessModes: [ "ReadWriteOnce" ]
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
The accessMode value quoted in the example is a string whereas it should be an array.
Fixed it by creating an array.