### PR TITLE
using_minikube.md: Fixed typo

### DIFF
--- a/docs/using_minikube.md
+++ b/docs/using_minikube.md
@@ -92,7 +92,7 @@ On your Ubuntu host, do the following.
 
 ### Verifying that Minikube is Configured
 
-Check that minikube is configured and is using the following command.
+Check that minikube is configured using the following command.
 
     minikube status
 


### PR DESCRIPTION
Fixed a small typo in the Minikube configuration verifying section.

Signed-off-by: Bihan V de Silva <bihanviranga@gmail.com>