### PR TITLE
typo : fixing double word use

### DIFF
--- a/docs/readonlyvolumes.md
+++ b/docs/readonlyvolumes.md
@@ -49,7 +49,7 @@ To avoid the data loss situation, this behavior is change in 0.6 release. Now, i
 
 For example, consider a Jiva volume with three replicas: 
 
-- Losing one replica will not affect the RW status of the volume, both the the remaining replicas will continue to be in RW mode
+- Losing one replica will not affect the RW status of the volume, both the remaining replicas will continue to be in RW mode
 - Losing second replica will mark the third replica as RO and the volume will also become RO
 
 

--- a/website/node_modules/asap/README.md
+++ b/website/node_modules/asap/README.md
@@ -220,7 +220,7 @@ tasks that guaranteed that they would not throw exceptions.
 This core is useful for promise implementations that capture thrown errors in
 rejected promises and do not need a second safety net.
 At the same time, the exception handling in `asap` was factored into separate
-implementations for Node.js and browsers, using the the [Browserify][Browser
+implementations for Node.js and browsers, using the [Browserify][Browser
 Config] `browser` property in `package.json` to instruct browser module loaders
 and bundlers, including [Browserify][], [Mr][], and [Mop][],  to use the
 browser-only implementation.

--- a/website/node_modules/babel-preset-env/CHANGELOG.md
+++ b/website/node_modules/babel-preset-env/CHANGELOG.md
@@ -174,7 +174,7 @@ If you are targeting the `node` environment exclusively, the always-included web
 
 When parsing plugin data, we weren't properly handling browser families. This caused
 `transform-es2015-block-scoping` and other plugins to be incorrectly added for Edge >= 12.
-(s/o to @mgol for the the report and review!)
+(s/o to @mgol for the report and review!)
 
 - Add typed array methods to built-ins features. ([#198](https://github.com/babel/babel-preset-env/pull/198)) (@yavorsky)
 

--- a/website/node_modules/http-signature/http_signing.md
+++ b/website/node_modules/http-signature/http_signing.md
@@ -320,7 +320,7 @@ The Authorization header would be:
 
 The `openssl` commandline tool can be used to generate or verify the signatures listed above.
 
-Compose the signing string as usual, and pipe it into the the `openssl dgst` command, then into `openssl enc -base64`, as follows:
+Compose the signing string as usual, and pipe it into the `openssl dgst` command, then into `openssl enc -base64`, as follows:
 
     $ printf 'date: Thu, 05 Jan 2014 21:31:40 GMT' | \
       openssl dgst -binary -sign /path/to/private.pem -sha256 | \

--- a/website/node_modules/source-map-support/README.md
+++ b/website/node_modules/source-map-support/README.md
@@ -27,7 +27,7 @@ If multiple sourceMappingURL comments exist in one file, the last sourceMappingU
 respected (e.g. if a file mentions the comment in code, or went through multiple transpilers).
 The path should either be absolute or relative to the compiled file.
 
-It is also possible to to install the source map support directly by
+It is also possible to install the source map support directly by
 requiring the `register` module which can be handy with ES6:
 
 ```js

--- a/website/node_modules/tcp-port-used/node_modules/q/README.md
+++ b/website/node_modules/tcp-port-used/node_modules/q/README.md
@@ -791,7 +791,7 @@ From previous event:
     at Object.<anonymous> (/path/to/test.js:7:1)
 ```
 
-Note how you can see the the function that triggered the async operation in the
+Note how you can see the function that triggered the async operation in the
 stack trace! This is very helpful for debugging, as otherwise you end up getting
 only the first line, plus a bunch of Q internals, with no sign of where the
 operation started.


### PR DESCRIPTION
Fixing the typo double use of words: "to" and "the"
Signed-off-by: Daniel Pisanu <stacatogit@gmail.com>