### PR TITLE
Create MIT LICENSE Per Docusaurus Requirement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 OpenEBS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Helping out in the spirit of Hacktoberfest :smile: :fallen_leaf:  :maple_leaf: 

Per the requirement of Facebook and Docusaurus, an MIT LICENSE file must be in the root directory of the source tree.

For example, the following files claim in the comments to find the MIT license file in the repo root:
https://github.com/openebs/openebs-docs/blob/33f5c62b264e0faf484e2f7633a47aa425b244e2/website/pages/en/users.js#L4

https://github.com/openebs/openebs-docs/blob/33f5c62b264e0faf484e2f7633a47aa425b244e2/website/pages/en/help.js#L4

https://github.com/openebs/openebs-docs/blob/33f5c62b264e0faf484e2f7633a47aa425b244e2/website/core/Footer.js#L4

https://github.com/openebs/openebs-docs/blob/33f5c62b264e0faf484e2f7633a47aa425b244e2/website/pages/en/index.js#L4

This PR adds the MIT license to the root of the Docs repo.

License adapted from the Docusaurous repo and formatted properly for Github viewing
https://github.com/facebook/Docusaurus/blob/master/LICENSE

Feel free to change the copyright year(s) as you see fit.  :+1: 
