### PR TITLE
Correct edit url for v0.7 docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -30,7 +30,7 @@ const siteConfig = {
   ],
   users,
   onPageNav: 'separate',
-  editUrl: 'https://github.com/openebs/openebs-docs/edit/staging/docs/',
+  editUrl: 'https://github.com/openebs/openebs-docs/edit/0.7/docs/',
   createIssueUrl: 'https://github.com/openebs/openebs/issues/new/',
   /* path to images for header/footer */
   headerIcon: 'img/OpenEBS-logo.svg',


### PR DESCRIPTION
This PR will rectify the edit url for v0.7 docs which is still pointing to the staging branch instead of 0.7 branch while someone tries to edit and send a PR for v0.7 openebs docs.

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>