### PR TITLE
Correct edit URL for v0.6 docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -30,7 +30,7 @@ const siteConfig = {
   ],
   users,
   onPageNav: 'separate',
-  editUrl: 'https://github.com/openebs/openebs-docs/edit/staging/docs/',
+  editUrl: 'https://github.com/openebs/openebs-docs/edit/0.6/docs/',
   /* path to images for header/footer */
   headerIcon: 'img/openebs-logo.svg',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
Edit URL for v0.6 docs should point to branch 0.6 instead of staging branch.

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>