### PR TITLE
Add css changes for nocopy class 

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -353,3 +353,8 @@ redoc .operation-type {
   display: table;
   clear: both;
 }
+
+.nocopy {
+    background: #F0F0F0;
+    color: #000;
+}


### PR DESCRIPTION
This PR will add css changes for nocopy class so that code blocks using class `nocopy` comes without copy button.

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>