### PR TITLE
Update postgres helm install command to supply proper storageClass

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -72,7 +72,7 @@ As shown above, OpenEBS volumes need to be configured with single replica. This 
    Install PostgreSQL on OpenEBS volume using the following command.
 
    ```
-   helm install --name my-release --storage-class=openebs-cstor-disk replication.slaveReplicas=2 stable/postgresql
+   helm install --name my-release persistence.storageClass=openebs-cstor-disk replication.slaveReplicas=2 stable/postgresql
    ```
 
 <br>


### PR DESCRIPTION
According to https://github.com/helm/charts/blob/master/stable/postgresql/README.md proper parameter to set storage class is `persistence.storageClass`.

Following error was caught during installation:
```
$ helm install --name postgres --storage-class=openebs-ssd replication.slaveReplicas=2 stable/postgresql --tls
Error: unknown flag: --storage-class
```