### PR TITLE
update mayactl page to link to troubleshooting

### DIFF
--- a/docs/mayactl.md
+++ b/docs/mayactl.md
@@ -1,7 +1,7 @@
 ---
 id: mayactl
-title: Mayactl
-sidebar_label: Mayactl
+title: mayactl
+sidebar_label: mayactl
 ---
 ------
 
@@ -283,7 +283,7 @@ m-apiserver status:  running
 
 ### [Day 2 Operations](/docs/next/operations.html)
 
-### [Jiva User Guide](/docs/next/jivaguide.html)
+### [Troubleshooting Guide](/docs/next/troubleshooting.html)
 
 ### <br>
 


### PR DESCRIPTION
Added the reference to troubleshooting instead of Jiva User Guide. 
Also made cosmetic changes to page title. `Mayactl` changed to `mayactl`  - I am unsure if this change requires me to update in some other place - like is there a page that holds all the side titles?