### PR TITLE
Remove algolia search support from 0.5 docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -13,18 +13,18 @@ const siteConfig = {
   url: 'https://docs.openebs.io' /* your website url */,
   baseUrl: '/v050/' /* base url for your project */,
   projectName: 'OpenEBS',
-
+/*
   algolia: {
     apiKey: "dc657dfe30f42f228671f557f49ced7a",
     indexName: "openebs",
     inputSelector: "### REPLACE ME ####",
     debug: true
     },
-
+*/
     headerLinks: [
        
         {
-            search: true
+            search: false
         },
     //{page: 'help', label: 'Help'},
   ],


### PR DESCRIPTION
This change is required to make algolia search be able to search for data or content within a particular doc version only rather than searching in all the docs version.
This happens since we are making use of the same algolia API key across all the versions of openebs docs.

**Note**: We will have to look for a way to enable search in all the docs version instead of one.

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>