### PR TITLE
Change start urls in order to crawl only the latest docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -17,6 +17,7 @@ const siteConfig = {
   algolia: {
     apiKey: "dc657dfe30f42f228671f557f49ced7a",
     indexName: "openebs",
+    startUrls: ["https://docs.openebs.io/docs/next"],
     inputSelector: "### REPLACE ME ####",
     debug: true
     },


### PR DESCRIPTION
This change is required in order to see if this change restricts the algolia crawler from crawling websites other than our latest one.
Needs to be in staging for atleast 24 hour as the crawler runs every 24 hr.

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>