### PR TITLE
Update staging as part of 1.2 release

### DIFF
--- a/docs/kb.md
+++ b/docs/kb.md
@@ -20,9 +20,12 @@ sidebar_label: Knowledge Base
 
 [How to prevent container logs from exhausting disk space?](#enable-log-rotation-on-cluster-nodes)
 
+[How to create a BlockDeviceClaim for a particular BlockDevice?](#create-bdc-for-a-blockdevice) 
+
 </br>
 
 <h3><a class="anchor" aria-hidden="true" id="resuse-pv-after-recreating-sts"></a>How do I reuse an existing PV - after re-creating Kubernetes StatefulSet and its PVC</h3>
+
 
 There are some cases where it had to delete the StatefulSet and re-install a new StatefulSet. In the process you may have to delete the PVCs used by the StatefulSet and retain PV policy by ensuring the Retain as the "Reclaim Policy". In this case, following are the procedures for re-using an existing PV in your StatefulSet application.
 
@@ -121,7 +124,7 @@ There are some cases where it had to delete the StatefulSet and re-install a new
 
 7. Get the newly created PVC UID using `kubectl get pvc mongo-persistent-storage-mongo-0 -o yaml`.
 
-       
+  
 
 8. Update the uid under the claimRef in the PV using the following command. The PVC will get attached to the PV after editing the pv with correct uid.
 
@@ -158,6 +161,7 @@ There are some cases where it had to delete the StatefulSet and re-install a new
 
 
 <h3><a class="anchor" aria-hidden="true" id="how-to-scale-up-jiva-replica"></a>How to scale up Jiva replica?</h3>
+
 
 From 0.9.0 OpenEBS version, Jiva pod deployment are scheduling with nodeAffinity. For scaling up Jiva replica count, the following steps has to be performed.
 
@@ -235,6 +239,7 @@ From 0.9.0 OpenEBS version, Jiva pod deployment are scheduling with nodeAffinity
 </br>
 
 <h3><a class="anchor" aria-hidden="true" id="OpenEBS-install-openshift-4.1"></a>How to install OpenEBS in OpenShift 4.1</h3>
+
 
 In earlier documentation, it was referred to install OpenEBS by disabling SELinux. But, you can install OpenEBS in OpenShift environment without disabling SELinux using the following steps.
 
@@ -340,6 +345,7 @@ In earlier documentation, it was referred to install OpenEBS by disabling SELinu
 
 <h3><a class="anchor" aria-hidden="true" id="enable-admission-controller-in-openshift"></a>How to enable Admission-Controller in OpenShift 3.10 and above</h3>
 
+
 The following proceedure will help to enable admission-controller in OpenShift 3.10 and above.
 
 1. Update the `/etc/origin/master/master-config.yaml`  file with below configuration.
@@ -371,6 +377,7 @@ The following proceedure will help to enable admission-controller in OpenShift 3
 <br>
 
 <h3><a class="anchor" aria-hidden="true" id="how-to-setup-default-podsecuritypolicy-to-allow-the-openebs-pods-to-work-with-all-permissions"></a>How to setup default PodSecurityPolicy to allow the OpenEBS pods to work with all permissions?</h3>
+
 
 Apply the following YAML in your cluster.
 
@@ -447,6 +454,7 @@ Apply the following YAML in your cluster.
 <br>
 
 <h3><a class="anchor" aria-hidden="true" id="enable-log-rotation-on-cluster-nodes"></a>How to prevent container logs from exhausting disk space?</h3>
+
 
 Container logs, if left unchecked, can eat into the underlying disk space causing `disk-pressure` conditions
 leading to eviction of pods running on a given node. This can be prevented by performing log-rotation
@@ -534,6 +542,36 @@ the node to show up as `Not Ready` until the daemon has restarted successfully.
 
 - The log-opt `compress: true:` is supported from Docker version: 18.04.0. The `max-file` & `max-size` opts are supported
   on earlier releases as well.
+
+<br>
+
+<a href="#top">Go to top</a>
+
+<h3><a class="anchor" aria-hidden="true" id="create-bdc-for-a-blockdevice"></a>How to create a BlockDeviceClaim for a particular BlockDevice? </h3>
+
+
+
+There are certain use cases where the user does not need some of the BlockDevices discovered by OpenEBS to be used by any of the storage engines (cStor, LocalPV, etc.). In such scenarios, users can manually create a BlockDeviceClaim to claim that particular BlockDevice, so that it won't be used by cStor or Local PV. The following steps can be used  to claim a particular BlockDevice: 
+
+1. Download the BDC CR YAML from `node-disk-manager` repository.
+
+   ```
+   wget https://raw.githubusercontent.com/openebs/node-disk-manager/master/deploy/crds/openebs_v1alpha1_blockdeviceclaim_cr.yaml
+   ```
+
+2.  Provide the BD name of the corresponding BlockDevice which can be obtained by running `kubectl get bd -n <openebs_installed_namespace>` 
+
+3.  Apply the modified YAML spec using the following command:
+
+   ```
+   kubectl apply -f openebs_v1alpha1_blockdeviceclaim_cr.yaml
+   ```
+
+4.  Verify if particular BD is claimed using the following command:
+
+   ```
+   kubectl get bdc -n <openebs_installed_namespace>
+   ```
 
 <br>
 

--- a/docs/kb.md
+++ b/docs/kb.md
@@ -285,38 +285,7 @@ In earlier documentation, it was referred to install OpenEBS by disabling SELinu
    openebs-provisioner-5dfd95987b-nhwb9          1/1     Running   0          60m
    openebs-snapshot-operator-5d58bd848b-94nnt    2/2     Running   0          60m </div>
 
-5. For provisioning OpenEBS volumes, you have to edit SCC to allow HostPath volumes and Privileged containers. This can be done in two ways. 
-
-   - Using “Restricted” SCC
-   - Using “Privileged” SCC
-
-   <font size="5">Using “Restricted” SCC</font>
-
-   By default, **any/all users** (manual, serviceaccount), use the “restricted” securityContextConstraint (SCC). This SCC doesn’t allow: 
-
-   - HostPath Volumes
-   - Privileged Containers
-
-   Following have to be set to ensure volume replica pods can run on the cluster:
-
-   ```
-   allowHostDirVolumePlugin: true
-   allowPrivilegeEscalation: true
-   allowPrivilegedContainer: true
-   ```
-
-   Run following command from OpenShift cluster.
-
-   ```
-   oc edit scc restricted
-   ```
-
-   It will show an output similar to the following.
-
-   <div class="co">could not be patched: the body of the request was in an unknown format - accepted media types include: application/json-patch+json, application/merge-patch+json
-   You can run `oc replace -f /tmp/oc-edit-vvh25.yaml` to try this update again.</div>
-
-   **Note:** The above command will not patch the SCC directly. It will generate a temporary file and you have to run the mentioned command in the output to update the restricted SCC.
+5. For provisioning OpenEBS volumes, you have to edit SCC to allow HostPath volumes and Privileged containers. This can be done by following way. 
 
    <font size="5">Using “Privileged” SCC</font>
 

--- a/docs/kb.md
+++ b/docs/kb.md
@@ -22,9 +22,12 @@ sidebar_label: Knowledge Base
 
 [How to create a BlockDeviceClaim for a particular BlockDevice?](#create-bdc-for-a-blockdevice) 
 
+[How to provision Local PV on K3OS?](#provision-localpv-on-k3os)
+
 </br>
 
 <h3><a class="anchor" aria-hidden="true" id="resuse-pv-after-recreating-sts"></a>How do I reuse an existing PV - after re-creating Kubernetes StatefulSet and its PVC</h3>
+
 
 
 There are some cases where it had to delete the StatefulSet and re-install a new StatefulSet. In the process you may have to delete the PVCs used by the StatefulSet and retain PV policy by ensuring the Retain as the "Reclaim Policy". In this case, following are the procedures for re-using an existing PV in your StatefulSet application.
@@ -163,6 +166,7 @@ There are some cases where it had to delete the StatefulSet and re-install a new
 <h3><a class="anchor" aria-hidden="true" id="how-to-scale-up-jiva-replica"></a>How to scale up Jiva replica?</h3>
 
 
+
 From 0.9.0 OpenEBS version, Jiva pod deployment are scheduling with nodeAffinity. For scaling up Jiva replica count, the following steps has to be performed.
 
 1. Get the deployment details of replica of corresponding Jiva volume using the following command. If it is deployed in `openebs` namespace, use corresponding namespace appropriately in the following commands.
@@ -239,6 +243,7 @@ From 0.9.0 OpenEBS version, Jiva pod deployment are scheduling with nodeAffinity
 </br>
 
 <h3><a class="anchor" aria-hidden="true" id="OpenEBS-install-openshift-4.1"></a>How to install OpenEBS in OpenShift 4.1</h3>
+
 
 
 In earlier documentation, it was referred to install OpenEBS by disabling SELinux. But, you can install OpenEBS in OpenShift environment without disabling SELinux using the following steps.
@@ -346,7 +351,8 @@ In earlier documentation, it was referred to install OpenEBS by disabling SELinu
 <h3><a class="anchor" aria-hidden="true" id="enable-admission-controller-in-openshift"></a>How to enable Admission-Controller in OpenShift 3.10 and above</h3>
 
 
-The following proceedure will help to enable admission-controller in OpenShift 3.10 and above.
+
+The following procedure will help to enable admission-controller in OpenShift 3.10 and above.
 
 1. Update the `/etc/origin/master/master-config.yaml`  file with below configuration.
 
@@ -377,6 +383,7 @@ The following proceedure will help to enable admission-controller in OpenShift 3
 <br>
 
 <h3><a class="anchor" aria-hidden="true" id="how-to-setup-default-podsecuritypolicy-to-allow-the-openebs-pods-to-work-with-all-permissions"></a>How to setup default PodSecurityPolicy to allow the OpenEBS pods to work with all permissions?</h3>
+
 
 
 Apply the following YAML in your cluster.
@@ -454,6 +461,7 @@ Apply the following YAML in your cluster.
 <br>
 
 <h3><a class="anchor" aria-hidden="true" id="enable-log-rotation-on-cluster-nodes"></a>How to prevent container logs from exhausting disk space?</h3>
+
 
 
 Container logs, if left unchecked, can eat into the underlying disk space causing `disk-pressure` conditions
@@ -547,7 +555,7 @@ the node to show up as `Not Ready` until the daemon has restarted successfully.
 
 <a href="#top">Go to top</a>
 
-<h3><a class="anchor" aria-hidden="true" id="create-bdc-for-a-blockdevice"></a>How to create a BlockDeviceClaim for a particular BlockDevice? </h3>
+<h3><a class="anchor" aria-hidden="true" id="create-bdc-for-a-blockdevice"></a>How to create a BlockDeviceClaim for a particular BlockDevice?</h3>
 
 
 
@@ -572,6 +580,121 @@ There are certain use cases where the user does not need some of the BlockDevice
    ```
    kubectl get bdc -n <openebs_installed_namespace>
    ```
+
+<br>
+
+<a href="#top">Go to top</a>
+
+<h3><a class="anchor" aria-hidden="true" id="provision-localpv-on-k3os"></a>How to provision Local PV on K3OS?</h3>
+
+
+
+K3OS can be installed on any hypervisor The procedure for deploying K3OS on VMware environment is provided in the following section. There are 3 steps for provisioning OpenEBS Local PV on K3OS.
+
+1. Configure server(master)
+2. Configure agent(worker)
+3. Deploying OpenEBS
+
+The detailed information of each steps are provided below.
+
+- **Configure server(master)**
+
+  - Download the ISO file from the latest [release](https://github.com/rancher/k3os/releases) and create a virtual machine in VMware. Mount the ISO file into hypervisor and start a virtual machine.
+
+  - Select **Run k3OS LiveCD or Installation** and press <ENTER>.
+
+  - The system will boot-up and gives you the login prompt.
+
+  - Login as **rancher** user without providing password.
+
+  - Set a password for **rancher** user to enable connectivity from other machines by running `sudo passwd rancher`.
+
+  - Now, install K3OS into disk. This can be done by running the command `sudo os-config`.
+
+  - Choose the option 1.Install to disk . Answer the proceeding questions and provide rancher user password.
+
+  - As part of above command execution, you can configure the host as either server or agent. Select `1.server` to configure K3s master.
+
+  - While configuring server, set cluster secret which would be used while joining nodes to the server. After successful installation and server reboot, check the cluster status.
+
+  - Run following command to get the details of nodes:
+
+    ```
+    kubectl get nodes
+    ```
+
+    Example output:
+
+    ```
+    NAME         STATUS   ROLES    AGE     VERSION
+    k3os-14539   Ready    <none>   2m33s   v1.14.1-k3s.4
+    ```
+
+- **Configure agent(worker)**
+
+  - Follow the above steps till installing K3OS into disk in all the hosts that you want to be part of K3s cluster.
+
+  - To configure kubernetes agent with K3OS, select the option `2. agent` while running `sudo os-config` command. You need to provide URL of server and secret configured during server configuration.
+
+  - After performing this, Kubernetes agent will be configured as follows and it will be added to the server.
+
+  - Check the cluster configuration by checking the nodes using the following command:
+
+    ```
+    Kubectl get nodes
+    ```
+
+    Example output:
+
+    ```
+    NAME         STATUS   ROLES    AGE     VERSION
+    k3os-14539   Ready    <none>   5m16s   v1.14.1-k3s.4
+    k3os-32750   Ready    <none>   49m     v1.14.1-k3s.4
+    ```
+
+- **Installing OpenEBS**
+
+  - Run the following command to install OpenEBS from master console:
+
+    ```
+    kubectl apply -f https://openebs.github.io/charts/openebs-operator-1.1.0.yaml
+    ```
+
+  - Check the OpenEBS components by running the following command:
+
+    ```
+    NAME                                           READY   STATUS              RESTARTS   AGE
+    maya-apiserver-78c966c446-zpvhh                1/1     Running             2          101s
+    openebs-admission-server-66f46564f5-8sz8c      1/1     Running             0          101s
+    openebs-localpv-provisioner-698496cf9b-wkf95   1/1     Running             0          101s
+    openebs-ndm-9kt4n                              0/1     ContainerCreating   0          101s
+    openebs-ndm-mxqcf                              0/1     ContainerCreating   0          101s
+    openebs-ndm-operator-7fb4894546-d2whz          1/1     Running             1          101s
+    openebs-provisioner-7f9c99cf9-9jlgc            1/1     Running             0          101s
+    openebs-snapshot-operator-79f7d56c7d-tk24k     2/2     Running             0          101s
+    ```
+
+    Note that `openebs-ndm` pods are in not created successfully. This is due to the lack of udev support in K3OS. More details can be found [here](https://github.com/openebs/openebs/issues/2686).
+
+  - Now user can install Local PV on this cluster. Check the StorageClasses created as part of OpenEBS deployment by running the following command.
+
+    ```
+    kubectl get sc
+    ```
+
+    Example output:
+
+    ```
+    NAME                        PROVISIONER                                                AGE
+    openebs-device              openebs.io/local                                           57m
+    openebs-hostpath            openebs.io/local                                           57m
+    openebs-jiva-default        openebs.io/provisioner-iscsi                               57m
+    openebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   57m
+    ```
+
+  - The default StorageClass `openebs-hostpath` can be used to create local PV on the path `/var/openebs/local` in your Kubernetes node. You can either use `openebs-hostpath` storage class to create volumes or create new storage class by following the steps mentioned [here.]([https://docs.openebs.io/docs/next/uglocalpv.html](https://docs.openebs.io/1.0.0-RC1/docs/next/uglocalpv.html)) 
+
+    **Note:** OpenEBS local PV will not be bound until the application pod is scheduled as its **volumeBindingMode** is set to **WaitForFirstConsumer.** Once the application pod is scheduled on a certain node, OpenEBS Local PV will be bound on that node.
 
 <br>
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -71,6 +71,7 @@ block volumes.
 
 <h3><a class="anchor" aria-hidden="true" id="ubuntu"></a>Ubuntu</h3>
 
+
 **Verify iSCSI services are configured**
 
 If an iSCSI initiator is already installed on your node, check that the
@@ -124,6 +125,7 @@ You can verify the iSCSI installation from above section.
 <br>
 
 <h3><a class="anchor" aria-hidden="true" id="rhel"></a>Red Hat Enterprise Linux</h3>
+
 
 **Verify iSCSI services are configured**
 
@@ -187,6 +189,7 @@ You can verify the iSCSI installation from above section.
 <br>
 
 <h3><a class="anchor" aria-hidden="true" id="centos"></a>CentOS</h3>
+
 
 **Verify iSCSI services are configured**
 
@@ -428,8 +431,8 @@ reboot
 
 | Operating system      | iSCSI Package         | Commands                                                     |
 | --------------------- | --------------------- | ------------------------------------------------------------ |
-| RHEL / CentOS         | iscsi-initiator-utils | yum install iscsi-initiator-utils -y <br />sudo systemctl enable iscsid && sudo systemctl start iscsid<br />modprobe iscsi_tcp |
-| Ubuntu 16.04 / Debian | open-iscsi            | sudo apt install open-iscsi<br />sudo systemctl enable iscsid && sudo systemctl start iscsid<br />modprobe iscsi_tcp |
+| RHEL / CentOS         | iscsi-initiator-utils | yum install iscsi-initiator-utils -y <br />sudo systemctl enable iscsid && sudo systemctl start iscsid<br />modprobe iscsi_tcp<br />echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf |
+| Ubuntu 16.04 / Debian | open-iscsi            | sudo apt install open-iscsi<br />sudo systemctl enable iscsid && sudo systemctl start iscsid<br />modprobe iscsi_tcp<br />echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf |
 
 
 
@@ -445,7 +448,9 @@ After installing the initiator tool on your nodes, edit the YAML for your cluste
         	- "/var/lib/iscsi:/var/lib/iscsi"
         	- "/lib/modules"
 
-<h4><a class="anchor" aria-hidden="true" id="rancher-ubuntu-18.04"></a>iSCSI services on Ubuntu 18.04</h4>
+
+
+<h4><a class="anchor" aria-hidden="true" id="rancher-ubuntu-18.04"></a>iSCSI services on Ubuntu 18.04 or CentOS 7.6</h4>
 **Step1:** By default, iSCSI service is not present on worker node. It will be running inside the kubelet. To verify presence of iSCSI service inside kubelet, run the following command:
 
 ```
@@ -460,9 +465,10 @@ iscsiadm version 2.0-874
 
 The following commands will enable the `iscsi_tcp` module and it will persist this changes to the system.
 
-| Operating system | iSCSI Package | Commands                                                     |
-| ---------------- | ------------- | ------------------------------------------------------------ |
-| Ubuntu 18.04     | open-iscsi    | modprobe iscsi_tcp <br />echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf |
+| Operating system | iSCSI Package         | Commands                                                     |
+| ---------------- | --------------------- | ------------------------------------------------------------ |
+| Ubuntu 18.04     | open-iscsi            | modprobe iscsi_tcp <br />echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf |
+| CentOS 7.6       | iscsi-initiator-utils | modprobe iscsi_tcp <br />echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf |
 
 **Step 2:** If you are using Jiva or Local PV for provisioning OpenEBS volume,  Add `extra_binds` under kubelet service in cluster YAML. If the volume is using a mounted path on the host, then you must add the mounted path under `extra_binds` section. 
 
@@ -473,7 +479,7 @@ services:
      - /var/openebs/local:/var/openebs/local
 ```
 
-In the above snippet, default hostpath which will be created on the worker node using `LocalPV-hostpath` StorageClass is added under `extra_binds`. This configuration will help to create default hostpath directory on worker node for provisioning `LocalPV-hostpath` volume.
+In the above snippet default hostpath, which will be created on the worker node using `LocalPV-hostpath` StorageClass, should be added under `extra_binds`. This configuration will help to create default hostpath directory on worker node for provisioning `LocalPV-hostpath` volume.
 
 <br>
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,7 +87,7 @@ Connecting Kubernetes cluster to MayaOnline is the simplest and easiest way to m
 
 ## NDM related
 
-[Blockdevice description is getting changed on node reboot](#bd-description-changed-on-node-reboot)
+[Blockdevices are not detected by NDM in some of the nodes](#bd-from-some-nodes-are-not-detected)
 
 <br>
 
@@ -769,11 +769,11 @@ You can resolve this issue by upgrading the Kubernetes cluster infrastructure re
 
 
 
-<h3><a class="anchor" aria-hidden="true" id="bd-description-changed-on-node-reboot"></a>Blockdevice description is getting changed on node reboot</h3>
+<h3><a class="anchor" aria-hidden="true" id="bd-from-some-nodes-are-not-detected"></a>Blockdevices are not detected by NDM from some of the nodes</h3>
 
 
 
-One disk is each attached per Node in a 3 Node cluster where Centos is underlying OS and `kubectl get blockdevice -n openebs`  return only one disk and if one node is restarted, the description of the disk attached to that node gets modified. `lsblk` output from one of the nodes:
+One disk is attached per Node in a 3 Node cluster in a VM Environment where CentOS is underlying OS and `kubectl get blockdevice -n openebs`  return only one disk. Also if the particular node is restarted, from where the disk is detected then the description of the disk attached to that node gets modified. `lsblk` output from one of the nodes:
 
 ```
 NAME            MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
@@ -788,11 +788,11 @@ sr0              11:0    1 1024M  0 rom
 
 **Troubleshooting:**
 
-Check `kubectl get blockdevice -o yaml` of one of the disks and check its serial number. Also ensure that serial number of other 2 disks are different. If the serial number of all disks are same, then NDM will detect only the first one. For NDM to detect the disk uniquely, disks have to have at least one of WWN, Model, Serial or Vendor property must be unique.
+Check `kubectl get blockdevice -o yaml` of one of the blockdevice and check its serial number. Also ensure that serial number of other 2 blockdevices are different. NDM detect and recognise the blockdevice based on their WWN, Model, Serial and Vendor. If the blockdevice have all the parameters same then NDM cannot differentiate the blockdevice and will create only 1 BlockdDevice CR for each unique parameter. To troubleshoot the same user has to make sure the blockdevices are having at least any one unique parameter from WWN, Model, Serial and Vendor. Usually this issue faced in virtualization environment like vSphere, KVM etc.
 
 **Resolution:**
 
-Download custom blockdevice CR YAML file from [here](https://raw.githubusercontent.com/openebs/node-disk-manager/master/deploy/crds/openebs_v1alpha1_blockdevice_cr.yaml) and apply with the details of each block device. In the sample spec, `ndm.io/managed:` is set to false. So NDM will not mange this <br>blockdevice.
+Download custom blockdevice CR YAML file from [here](https://raw.githubusercontent.com/openebs/node-disk-manager/master/deploy/crds/openebs_v1alpha1_blockdevice_cr.yaml) and apply with the details of each block device. In the sample spec, `ndm.io/managed:` is set to false. So NDM will not manage this <br>blockdevice.
 
 **Note:** If you are creating a block device CR manually for a custom device path, then you must add the corresponding device path under `exclude` filter so that NDM will not select the particular device for BD creation. For example, if block device CR is creating for `/dev/sdb` manually, then you must add `/dev/sdb` under `exclude` filter of NDM configuration. See [here](#Exclude-filters) for customizing the `exclude` filter in NDM configuration.
 

--- a/docs/ugcstor.md
+++ b/docs/ugcstor.md
@@ -281,6 +281,7 @@ spec:
     bucket: <YOUR_BUCKET>
     prefix: <PREFIX_FOR_BACKUP_NAME>
     backupPathPrefix: <PREFIX_FOR_BACKUP_PATH>
+    namespace: <openebs_installed_namespace>
     provider: <GCP_OR_AWS>
     region: <AWS_REGION or minio>
 ```
@@ -291,6 +292,7 @@ The following are the definition for each parameters.
 - bucket : Provide the bucket name created on the cloud provider. Eg: gcpbucket
 - prefix : Prefix for backup name. Eg: cstor
 - backupPathPrefix: Prefix for backup path. Eg: newbackup. This should be same as `prefix` mentioned in `05-backupstoragelocation.yaml` for keeping all backups at same path.  For more details , please refer [here](https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/). 
+- namespace : (Optional) Provide the namespace where OpenEBS is installed. OpenEBS velero plugin will automatically take the OpenEBS installed namespace in the absence of this parameter. 
 - Provider : Provider name. Eg: gcp or aws
 - region : Provide region name if cloud provider is AWS or use `minio` if it is a MinIO bucket.
 
@@ -310,6 +312,7 @@ spec:
   config:
     bucket: gcpbucket
     prefix: cstor
+    namespace: openebs
     backupPathPrefix: newbackup
     provider: gcp
 ```


### PR DESCRIPTION
Updated the following pages:
1. Steps for provisioning Local Pv on K3OS
2. Add namespace filed in volumesnapshotlocation(cstor backup)
3. Add extra-binds for Local PV and Jiva creation in Centos7.6 on Rancher RKE
4. Change heading to Bds are not detected from some nodes(NDM troubleshooting)
5. Added in troubleshooting related to misconfigured webhooks causing provisioning failures. 
6. Manually creating BDC -- For avoiding disk to be picked by LocalPV
7. Removed restricted SCC section in installation of OpenEBS in openshift 4.1(KB article page)


Signed-off-by: ranjithwingrider <ranjith.raveendran@mayadata.io>