### PR TITLE
Fix elasticsearch typo 

### DIFF
--- a/docs/assets/svg/elasticsearch-deployment.svg
+++ b/docs/assets/svg/elasticsearch-deployment.svg
@@ -152,7 +152,7 @@
 		<line class="st3" x1="1827.6" y1="689.6" x2="1827.6" y2="686.6"/>
 		<path class="st13" d="M1455.4,101H621.9c-6.4,0-11.5-5.1-11.5-11.5l0,0V49.1c0-6.4,5.1-11.5,11.5-11.5h833.4
 			c6.4,0,11.5,5.1,11.5,11.5v40.4C1466.9,95.8,1461.8,100.9,1455.4,101C1455.5,101,1455.5,101,1455.4,101z"/>
-		<text transform="matrix(0.94 0 0 1 646.8201 81.2276)" class="st4 st7 st14">OpenEBS as persistent storage for ElasticSearch</text>
+		<text transform="matrix(0.94 0 0 1 646.8201 81.2276)" class="st4 st7 st14">OpenEBS as persistent storage for Elasticsearch</text>
 		<g>
 			<g>
 				<line class="st15" x1="585.1" y1="626" x2="585.1" y2="683.4"/>
@@ -176,7 +176,7 @@
 				</g>
 			</g>
 		</g>
-		<text transform="matrix(0.9445 0 0 1 611.9976 615.587)" class="st16 st5 st17">ElasticSearch DB replicated to 3 copies</text>
+		<text transform="matrix(0.9445 0 0 1 611.9976 615.587)" class="st16 st5 st17">Elasticsearch DB replicated to 3 copies</text>
 		<text transform="matrix(0.94 0 0 1 843.6201 815.5402)" class="st4 st5 st6">cStorPool instance2</text>
 		<text transform="matrix(0.94 0 0 1 1184.5 811.67)" class="st4 st5 st6">cStorPool instance3</text>
 		<text transform="matrix(0.94 0 0 1 1552.5 815.5402)" class="st4 st5 st6">cStorPool instance4</text>

--- a/docs/cassandra.md
+++ b/docs/cassandra.md
@@ -43,7 +43,7 @@ Apache Cassandra is a distributed NoSQL database management system designed to h
 
 <br>
 
-<img src="/docs/assets/svg/cassandra-deployment.svg" alt="OpenEBS and Elasticsearch" style="width:100%;">
+<img src="/docs/assets/svg/cassandra-deployment.svg" alt="OpenEBS and Cassandra" style="width:100%;">
 
 <br>
 

--- a/docs/cassandra.md
+++ b/docs/cassandra.md
@@ -43,7 +43,7 @@ Apache Cassandra is a distributed NoSQL database management system designed to h
 
 <br>
 
-<img src="/docs/assets/svg/cassandra-deployment.svg" alt="OpenEBS and ElasticSearch" style="width:100%;">
+<img src="/docs/assets/svg/cassandra-deployment.svg" alt="OpenEBS and Elasticsearch" style="width:100%;">
 
 <br>
 

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -1,10 +1,10 @@
 ---
-id: elasticsearch
-title: OpenEBS for ElasticSearch
-sidebar_label: ElasticSearch
+id: Elasticsearch
+title: OpenEBS for Elasticsearch
+sidebar_label: Elasticsearch
 ---
 
-<img src="/docs/assets/o-elastic.png" alt="OpenEBS and ElasticSearch" style="width:400px;">
+<img src="/docs/assets/o-elastic.png" alt="OpenEBS and Elasticsearch" style="width:400px;">
 
 <br>
 
@@ -12,20 +12,20 @@ sidebar_label: ElasticSearch
 
 <br>
 
-EFK is the most popular cloud native logging solution on Kubernetes for On-Premise as well as cloud platforms. In the EFK stack, ElasticSearch is a stateful application that needs persistent storage. Logs of production applications need to be stored for a long time which requires reliable and highly available storage.  OpenEBS and EFK together provides a complete logging solution.
+EFK is the most popular cloud native logging solution on Kubernetes for On-Premise as well as cloud platforms. In the EFK stack, Elasticsearch is a stateful application that needs persistent storage. Logs of production applications need to be stored for a long time which requires reliable and highly available storage.  OpenEBS and EFK together provides a complete logging solution.
 
 
 
-Advantages of using OpenEBS for ElasticSearch database:
+Advantages of using OpenEBS for Elasticsearch database:
 
 - All the logs data is stored locally and managed natively to Kubernetes
 - Start with small storage and add disks as needed on the fly
 - Logs are are highly available. When a node fails or rebooted during upgrades, the persistent volumes from OpenEBS continue to be highly available. 
-- If required, take backup of the ElasticSearch database periodically and back them up to S3 or any object storage so that restoration of the same logs is possible to the same or any other Kubernetes cluster
+- If required, take backup of the Elasticsearch database periodically and back them up to S3 or any object storage so that restoration of the same logs is possible to the same or any other Kubernetes cluster
 
 <br>
 
-*Note: ElasticSearch can be deployed both as `deployment` or as `statefulset`. When ElasticSearch deployed as `statefulset`, you don't need to replicate the data again at OpenEBS level. When ElasticSearch is deployed as `deployment`, consider 3 OpenEBS replicas, choose the StorageClass accordingly.*
+*Note: Elasticsearch can be deployed both as `deployment` or as `statefulset`. When Elasticsearch deployed as `statefulset`, you don't need to replicate the data again at OpenEBS level. When Elasticsearch is deployed as `deployment`, consider 3 OpenEBS replicas, choose the StorageClass accordingly.*
 
 <br>
 
@@ -41,7 +41,7 @@ Advantages of using OpenEBS for ElasticSearch database:
 
 
 
-<img src="/docs/assets/svg/elasticsearch-deployment.svg" alt="OpenEBS and ElasticSearch" style="width:100%;">
+<img src="/docs/assets/svg/Elasticsearch-deployment.svg" alt="OpenEBS and Elasticsearch" style="width:100%;">
 
 <br>
 
@@ -65,17 +65,17 @@ Advantages of using OpenEBS for ElasticSearch database:
 
 4. **Create Storage Class**
 
-   You must configure a StorageClass to provision cStor volume on given cStor pool. StorageClass is the interface through which most of the OpenEBS storage policies are defined. In this solution we are using a StorageClass to consume the cStor Pool which is created using external disks attached on the Nodes.  Since ElasticSearch is a StatefulSet, it requires only single storage replica. So cStor volume `replicaCount` is >=1. Sample YAML named **openebs-sc-disk.yaml**to consume cStor pool with cStoveVolume Replica count as 1 is provided in the configuration details below.
+   You must configure a StorageClass to provision cStor volume on given cStor pool. StorageClass is the interface through which most of the OpenEBS storage policies are defined. In this solution we are using a StorageClass to consume the cStor Pool which is created using external disks attached on the Nodes.  Since Elasticsearch is a StatefulSet, it requires only single storage replica. So cStor volume `replicaCount` is >=1. Sample YAML named **openebs-sc-disk.yaml**to consume cStor pool with cStoveVolume Replica count as 1 is provided in the configuration details below.
 
-5. **Launch and test ElasticSearch**
+5. **Launch and test Elasticsearch**
 
-   Use latest ElasticSearch chart with helm to deploy ElasticSearch in your cluster using the following command. In the following command, it will create PVC with 30G size.
+   Use latest Elasticsearch chart with helm to deploy Elasticsearch in your cluster using the following command. In the following command, it will create PVC with 30G size.
 
    ```
-   helm install --name es-test --set volumeClaimTemplate.storageClassName=openebs-cstor-disk elastic/elasticsearch --version 6.6.0-alpha1
+   helm install --name es-test --set volumeClaimTemplate.storageClassName=openebs-cstor-disk elastic/Elasticsearch --version 6.6.0-alpha1
    ```
 
-   For more information on installation, see ElasticSearch [documentation](https://github.com/elastic/helm-charts/tree/master/elasticsearch).
+   For more information on installation, see Elasticsearch [documentation](https://github.com/elastic/helm-charts/tree/master/Elasticsearch).
 
 <br>
 
@@ -89,13 +89,13 @@ Advantages of using OpenEBS for ElasticSearch database:
 
 
 
-A live deployment of ElasticSearch with Kibana using OpenEBS volumes can be seen at the website [www.openebs.ci](https://openebs.ci/)
+A live deployment of Elasticsearch with Kibana using OpenEBS volumes can be seen at the website [www.openebs.ci](https://openebs.ci/)
 
-Deployment YAML spec files for ElasticSearch and OpenEBS resources are found [here](https://github.com/openebs/e2e-infrastructure/blob/54fe55c5da8b46503e207fe0bc08f9624b31e24c/production/efk-server/elasticsearch/es-statefulset.yaml)
+Deployment YAML spec files for Elasticsearch and OpenEBS resources are found [here](https://github.com/openebs/e2e-infrastructure/blob/54fe55c5da8b46503e207fe0bc08f9624b31e24c/production/efk-server/Elasticsearch/es-statefulset.yaml)
 
-[OpenEBS-CI dashboard of ElasticSearch](https://openebs.ci/logging)
+[OpenEBS-CI dashboard of Elasticsearch](https://openebs.ci/logging)
 
-[Live access to ElasticSearch dashboard](https://e2elogs.openebs.ci/app/kibana)
+[Live access to Elasticsearch dashboard](https://e2elogs.openebs.ci/app/kibana)
 
 
 
@@ -117,7 +117,7 @@ It is not seamless to increase the cStor volume size (refer to the roadmap item)
 
 **Monitor cStor Pool size**
 
-As in most cases, cStor pool may not be dedicated to just elasticsearch database alone. It is recommended to watch the pool capacity and add more disks to the pool before it hits 80% threshold. See [cStorPool metrics](/docs/next/ugcstor.html#monitor-pool). 
+As in most cases, cStor pool may not be dedicated to just Elasticsearch database alone. It is recommended to watch the pool capacity and add more disks to the pool before it hits 80% threshold. See [cStorPool metrics](/docs/next/ugcstor.html#monitor-pool). 
 
 
 

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -1,5 +1,5 @@
 ---
-id: Elasticsearch
+id: elasticsearch
 title: OpenEBS for Elasticsearch
 sidebar_label: Elasticsearch
 ---
@@ -41,7 +41,7 @@ Advantages of using OpenEBS for Elasticsearch database:
 
 
 
-<img src="/docs/assets/svg/Elasticsearch-deployment.svg" alt="OpenEBS and Elasticsearch" style="width:100%;">
+<img src="/docs/assets/svg/elasticsearch-deployment.svg" alt="OpenEBS and Elasticsearch" style="width:100%;">
 
 <br>
 
@@ -117,7 +117,7 @@ It is not seamless to increase the cStor volume size (refer to the roadmap item)
 
 **Monitor cStor Pool size**
 
-As in most cases, cStor pool may not be dedicated to just Elasticsearch database alone. It is recommended to watch the pool capacity and add more disks to the pool before it hits 80% threshold. See [cStorPool metrics](/docs/next/ugcstor.html#monitor-pool). 
+As in most cases, cStor pool may not be dedicated to just elasticsearch database alone. It is recommended to watch the pool capacity and add more disks to the pool before it hits 80% threshold. See [cStorPool metrics](/docs/next/ugcstor.html#monitor-pool). 
 
 
 

--- a/docs/nuodb.md
+++ b/docs/nuodb.md
@@ -44,7 +44,7 @@ NuoDB’s distributed SQL database combines the elastic scale and continuous ava
 
 
 
-<img src="/docs/assets/svg/nuodb-deployment.svg" alt="OpenEBS and ElasticSearch" style="width:100%;">
+<img src="/docs/assets/svg/nuodb-deployment.svg" alt="OpenEBS and Elasticsearch" style="width:100%;">
 
 <br>
 

--- a/docs/nuodb.md
+++ b/docs/nuodb.md
@@ -44,7 +44,7 @@ NuoDB’s distributed SQL database combines the elastic scale and continuous ava
 
 
 
-<img src="/docs/assets/svg/nuodb-deployment.svg" alt="OpenEBS and Elasticsearch" style="width:100%;">
+<img src="/docs/assets/svg/nuodb-deployment.svg" alt="OpenEBS and NuoDB" style="width:100%;">
 
 <br>
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -39,7 +39,7 @@ OpenEBS is deployed under PostgreSQL for a variety of reasons discussed below.  
 
 <br>
 
-<img src="/docs/assets/svg/postgresql-deployment.svg" alt="OpenEBS and ElasticSearch" style="width:100%;">
+<img src="/docs/assets/svg/postgresql-deployment.svg" alt="OpenEBS and Elasticsearch" style="width:100%;">
 
 As shown above, OpenEBS volumes need to be configured with single replica. This configuration works fine when the nodes (hence the OpenEBS cStor pool) is deployed across Kubernetes zones.
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -39,8 +39,8 @@ OpenEBS is deployed under PostgreSQL for a variety of reasons discussed below.  
 
 <br>
 
-<img src="/docs/assets/svg/postgresql-deployment.svg" alt="OpenEBS and Elasticsearch" style="width:100%;">
-
+<img src="/docs/assets/svg/postgresql-deployment.svg" alt="OpenEBS and PostgreSQL" style="width:100%;">
+  
 As shown above, OpenEBS volumes need to be configured with single replica. This configuration works fine when the nodes (hence the OpenEBS cStor pool) is deployed across Kubernetes zones.
 
 <br>


### PR DESCRIPTION
This changes the application name 'ElasticSearch' to 'Elasticsearch' in OpenEBS docs.

Signed-off-by: Shivesh Abhishek <shivesh.abhishek@mayadata.io>