### PR TITLE
chore(docs): Update versions dropdown list

### DIFF
--- a/website/versions.json
+++ b/website/versions.json
@@ -2,11 +2,7 @@
   "versions": {
       "1.2.0": ["v1.2.0", "https://docs.openebs.io/v120/"],
       "1.1.0": ["v1.1.0", "https://docs.openebs.io/v110/"],
-      "1.0.0": ["v1.0.0", "https://docs.openebs.io/v100/"],
-      "0.9.0": ["v0.9.0", "https://docs.openebs.io/v090/"],
-      "0.8.2": ["v0.8.2", "https://docs.openebs.io/v082/"],
-      "0.8.1": ["v0.8.1", "https://docs.openebs.io/v081/"],
-      "0.8.0": ["v0.8", "https://docs.openebs.io/v080/"]
+      "1.0.0": ["v1.0.0", "https://docs.openebs.io/v100/"]
   }
 }
 


### PR DESCRIPTION
This PR now updates the version dropdown list to keep
docs link in the version dropdown from 1.0.0 onwards.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>