### PR TITLE
(refactor): Removing an extra command from Readme file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,13 @@ services:
 script:
   - python tag.py
   - cd website
-  - npm run build
+  - npm run build 
   - cd ..
-  - 
 after_success:
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then export REPO=mayadataio/openebs-docs;
      docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" && docker build -t $REPO:$TRAVIS_BRANCH-$COMMIT . && docker push $REPO; 
     fi
-  
+
   - if [ "$TRAVIS_BRANCH" = "staging" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then export REPO=mayadataio/stage-openebs-docs;
        docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" && docker build -t $REPO:$TRAVIS_BRANCH-$COMMIT . && docker push $REPO; 
     fi

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd openebs-docs
 ### Start the server
 
 ```bash
-cd openebs-docs/website
+cd website
 npm start
 ```
 


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- We are already in `openebs-docs` directory, so no need to use `cd openebs-docs/website`. we can directly use `cd website` 