### PR TITLE
chore(website): refactor and enhance css for docs

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "lodash":">=4.17.13",
     "cryptiles": "^4.1.2",
     "hawk": "^7.0.7",
-    "macaddress": "^0.2.9"
+    "macaddress": "^0.2.9",
+    "remarkable-admonitions": "^0.2.1"
   }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,9 +1,55 @@
 {
   "docs": {
-    "Introduction": ["overview","features", "usecases", "releases", "support"],
-    "Concepts": ["cas", "architecture", "casengines","cstor","jiva", "localpv", "ndm"],
-    "User Guides": ["quickstart", "prerequisites", "installation", "ugndm", "ugcstor", "jivaguide", "uglocalpv", "mayactl", "upgrade", "uninstall" ],
-    "Stateful Applications": ["mysql", "prometheus", "minio", "gitlab", "percona", "elasticsearch", "cassandra","nuodb", "postgres", "redis", "mongo", "jira", "rwm"],
-    "Advanced Topics": ["performance", "faq", "k8supgrades", "troubleshooting", "kb", "alphafeatures"]
+    "Introduction": [
+	"overview",
+	"features", 
+	"usecases", 
+	"releases", 
+	"support"
+	],
+    "Concepts": [
+	"cas", 
+	"architecture", 
+	"casengines",
+	"cstor",
+	"jiva", 
+	"localpv", 
+	"ndm"
+	],
+    "User Guides": [
+	"quickstart", 
+	"prerequisites", 
+	"installation", 
+	"ugndm", 
+	"ugcstor", 
+	"jivaguide", 
+	"uglocalpv", 
+	"mayactl", 
+	"upgrade", 
+	"uninstall" 
+	],
+    "Stateful Applications": [
+	"mysql", 
+	"prometheus", 
+	"minio", 
+	"gitlab", 
+	"percona", 
+	"elasticsearch", 
+	"cassandra",
+	"nuodb", 
+	"postgres", 
+	"redis", 
+	"mongo", 
+	"jira", 
+	"rwm"
+	],
+    "Advanced Topics": [
+	"performance", 
+	"faq", 
+	"k8supgrades", 
+	"troubleshooting", 
+	"kb", 
+	"alphafeatures"
+	]
   }
 }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -56,6 +56,10 @@ const siteConfig = {
   stylesheets: [
     '/css/code-blocks-buttons.css',
   ],
+  markdownPlugins: [
+    // Highlight admonitions.
+    require('remarkable-admonitions')({ icon: 'svg-inline' })
+  ],
 };
 
 module.exports = siteConfig;

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -382,26 +382,19 @@ redoc .operation-type {
 }
 
 .nocopy {
-    background: #F0F0F0;
-    color: #000;
+  background: #F0F0F0;
+  color: #000;
 }
 
 .co {
-  -webkit-column-width: 700px; /* Chrome, Safari, Opera */
-  -moz-column-width: 700px; /* Firefox */
-  column-width: 700px;
-  padding-left: 50px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  font-size: 14px;
+  margin: 20px 0;
+  padding: .5em;
+  font-size: 13px;
   font-family: monospace, monospace;
-  white-space: pre-wrap;
-  /*background-color: #f7f7f7;
-  background-color: #FCF2E8;
-  background-color: #fff5ee;
-  background-color: #fff8f3;*/
-  background-color: #FEF0EB;
-  border-radius: 15px;
+  white-space: pre;
+  background-color: #F0F0F0;
+  border-radius: 8px;
+  overflow-x: auto;
 }
 
 /* Adding Custom CSS for Feedback section */

--- a/website/static/css/docusaurus-admonitions.css
+++ b/website/static/css/docusaurus-admonitions.css
@@ -1,0 +1,103 @@
+/**
+ Docusaurus-like styling for `remarkable-admonitions` blocks
+ */
+
+.admonition {
+  margin-bottom: 1em;
+  margin-top: 1em;
+  padding: 15px 30px 15px 15px;
+}
+
+.admonition h5 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.admonition-icon {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.2em;
+}
+
+.admonition-icon svg {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  stroke-width: 0;
+}
+
+.admonition-content > :last-child {
+  margin-bottom: 0;
+}
+
+/** Customization */
+.admonition-warning {
+  background-color: rgba(230, 126, 34, 0.1);
+  border-left: 8px solid #e67e22;
+}
+
+.admonition-warning h5 {
+  color: #e67e22;
+}
+
+.admonition-warning .admonition-icon svg {
+  stroke: #e67e22;
+  fill: #e67e22;
+}
+
+.admonition-tip {
+  background-color: rgba(46, 204, 113, 0.1);
+  border-left: 8px solid #2ecc71;
+}
+
+.admonition-tip h5 {
+  color: #2ecc71;
+}
+
+.admonition-tip .admonition-icon svg {
+  stroke: #2ecc71;
+  fill: #2ecc71;
+}
+
+.admonition-caution {
+  background-color: rgba(231, 76, 60, 0.1);
+  border-left: 8px solid #e74c3c;
+}
+
+.admonition-caution h5 {
+  color: #e74c3c;
+}
+
+.admonition-caution .admonition-icon svg {
+  stroke: #e74c3c;
+  fill: #e74c3c;
+}
+
+.admonition-important {
+  background-color: rgba(52, 152, 219, 0.1);
+  border-left: 8px solid #3498db;
+}
+
+.admonition-important h5 {
+  color: #3498db;
+}
+
+.admonition-important .admonition-icon svg {
+  stroke: #3498db;
+  fill: #3498db;
+}
+
+.admonition-note {
+  background-color: rgba(241, 196, 15, 0.1);
+  border-left: 8px solid #f1c40f;
+}
+
+.admonition-note h5 {
+  color: #f1c40f;
+}
+
+.admonition-note .admonition-icon svg {
+  stroke: #f1c40f;
+  fill: #f1c40f;
+}


### PR DESCRIPTION
This commit adds CSS and markdown plugins to allow
rendering blockquote contents like tips, notes,
warnings and so forth.

Ref: https://github.com/favoloso/remarkable-admonitions

It also fixes the CSS for displaying code output.

Format the sideBars.json to make it easy to add
new content to TOC.

Signed-off-by: kmova <kiran.mova@mayadata.io>