### PR TITLE
chore(slack): update slack links to k8s/cncf slack

### DIFF
--- a/docs/alphafeatures.md
+++ b/docs/alphafeatures.md
@@ -7,7 +7,7 @@ sidebar_label: Alpha Features
 
 
 
-This section give different features of OpenEBS which is presently in Alpha version. These features are not recommend to perform on a production clusters. We suggest to familiarize these features on test clusters and reach out to OpenEBS [Community via slack](/docs/next/support.html) if you have  any queries or help on trying out these features.
+This section contains different features of OpenEBS which are presently in Alpha version. These features are not recommended to be used in production. We suggest you to familiarize and try these features on test clusters and reach out to [OpenEBS Community](/docs/next/support.html) if you have any queries, feedback or need help on these features.
 
 **Note** : Upgrade is not supported for features in Alpha version.
 

--- a/docs/alphafeatures.md
+++ b/docs/alphafeatures.md
@@ -7,7 +7,7 @@ sidebar_label: Alpha Features
 
 
 
-This section give different features of OpenEBS which is presently in Alpha version. These features are not recommend to perform on a production clusters. We suggest to familiarize these features on test clusters and reach out to OpenEBS [community slack](https://openebs.io/join-our-slack-community) if you have  any queries or help on trying out these features.
+This section give different features of OpenEBS which is presently in Alpha version. These features are not recommend to perform on a production clusters. We suggest to familiarize these features on test clusters and reach out to OpenEBS [Community via slack](/docs/next/support.html) if you have  any queries or help on trying out these features.
 
 **Note** : Upgrade is not supported for features in Alpha version.
 

--- a/docs/cstor.md
+++ b/docs/cstor.md
@@ -298,7 +298,7 @@ Following are most commonly observed areas of troubleshooting
 
    **Resolution**: 
 
-   This error eventually could get rectified on the further retries, volume gets mounted and application is started. This error is usually seen when cStor target takes some time to initialize  on low speed networks as it takes time to download cStor image binaries from repositories ( or )  or because the cstor target is waiting for the replicas to connect and establish quorum. If the error persists beyond 5 minutes, logs need to be verified, contact support or seek help on the <a href="/docs/next/support.html" target="_blank">Slack OpenEBS Community</a>.<br>
+   This error eventually could get rectified on the further retries, volume gets mounted and application is started. This error is usually seen when cStor target takes some time to initialize  on low speed networks as it takes time to download cStor image binaries from repositories ( or )  or because the cstor target is waiting for the replicas to connect and establish quorum. If the error persists beyond 5 minutes, logs need to be verified, contact <a href="/docs/next/support.html" target="_blank">OpenEBS Community</a> for support.<br>
 
 4. **Kubelet seen consuming high RAM usage with cStor volumes**
 

--- a/docs/cstor.md
+++ b/docs/cstor.md
@@ -298,7 +298,7 @@ Following are most commonly observed areas of troubleshooting
 
    **Resolution**: 
 
-   This error eventually could get rectified on the further retries, volume gets mounted and application is started. This error is usually seen when cStor target takes some time to initialize  on low speed networks as it takes time to download cStor image binaries from repositories ( or )  or because the cstor target is waiting for the replicas to connect and establish quorum. If the error persists beyond 5 minutes, logs need to be verified, contact support or seek help on the <a href="https://openebs.org/community" target="_blank">Slack OpenEBS Community</a>.<br>
+   This error eventually could get rectified on the further retries, volume gets mounted and application is started. This error is usually seen when cStor target takes some time to initialize  on low speed networks as it takes time to download cStor image binaries from repositories ( or )  or because the cstor target is waiting for the replicas to connect and establish quorum. If the error persists beyond 5 minutes, logs need to be verified, contact support or seek help on the <a href="/docs/next/support.html" target="_blank">Slack OpenEBS Community</a>.<br>
 
 4. **Kubelet seen consuming high RAM usage with cStor volumes**
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -172,7 +172,7 @@ If you have a Kubernetes environment, you can deploy OpenEBS using the following
 
 `kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml`
 
-You can then begin running a workload against OpenEBS. There is a large and growing number of workload that have storage classes that use OpenEBS. You need not use these specific storage classes. However, they may be helpful as they save time and allow for per workload customization. If you seek for any help,You can join at <a href="https://openebs.io/join-our-community" target="_blank">Slack OpenEBS</a> community channel.
+You can then begin running a workload against OpenEBS. There is a large and growing number of workload that have storage classes that use OpenEBS. You need not use these specific storage classes. However, they may be helpful as they save time and allow for per workload customization. If you need additional help, contact <a href="/docs/next/support.html" target="_blank">OpenEBS Support channels</a>.
  
 
 <a href="#top">Go to top</a>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -172,7 +172,7 @@ If you have a Kubernetes environment, you can deploy OpenEBS using the following
 
 `kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml`
 
-You can then begin running a workload against OpenEBS. There is a large and growing number of workload that have storage classes that use OpenEBS. You need not use these specific storage classes. However, they may be helpful as they save time and allow for per workload customization. If you need additional help, contact <a href="/docs/next/support.html" target="_blank">OpenEBS Support channels</a>.
+You can then begin running a workload against OpenEBS. There is a large and growing number of workload that have storage classes that use OpenEBS. You need not use these specific storage classes. However, they may be helpful as they save time and allow for per workload customization. If you need additional help, get in touch with <a href="/docs/next/support.html" target="_blank">OpenEBS Community</a>.
  
 
 <a href="#top">Go to top</a>

--- a/docs/support.md
+++ b/docs/support.md
@@ -34,6 +34,15 @@ Join our OpenEBS CNCF Mailing lists
 
 Join our weekly or monthly [community meetings](https://github.com/openebs/openebs/tree/master/community#community-meetings).
 
+## Commercial Support
+
+This is a list of third-party companies and individuals who provide products or services related to OpenEBS. OpenEBS is an independent open source project which does not endorse any company. The list is provided in alphabetical order.
+
+- [Clouds Sky GmbH](https://cloudssky.com/en/)
+- [CodeWave](https://codewave.eu/)
+- [Gridworkz Cloud Services](https://www.gridworkz.com/)
+- [MayaData](https://mayadata.io/)
+
 <br>
 
 <hr>

--- a/docs/support.md
+++ b/docs/support.md
@@ -6,14 +6,16 @@ sidebar_label: Support
 ------
 
 
+## GitHub
+
+Raise an [issue](https://github.com/openebs/openebs/issues/new)
 
 ## Slack
 
-The OpenEBS team hangs out on Slack in the `#openebs-users` channel. To participate in discussions with the OpenEBS team go to <a href="https://openebs.io/join-our-slack-community" target="_blank">Slack OpenEBS Community</a>
+You can reach out to OpenEBS contributors and maintainers through any of the following Slack Channels. 
 
-Slack requires registration, but the OpenEBS team welcomes anyone to register at <a href="https://openebs.io/join-our-slack-community" target="_blank">Slack OpenEBS Community</a>
-
-If you are on `Kubernetes Slack`, please join the <a href="https://kubernetes.slack.com/messages/openebs/" target="_blank">#openebs channel</a>. 
+- Join the [#openebs](https://kubernetes.slack.com/messages/openebs/) channel on the [Kubernetes Slack](https://slack.k8s.io).
+- Join the [#openebs](https://cloud-native.slack.com/messages/openebs/) channel on the [CNCF Slack](https://slack.cncf.io).
 
 
 ## Blogs
@@ -21,6 +23,16 @@ If you are on `Kubernetes Slack`, please join the <a href="https://kubernetes.sl
 Community blogs are available at [https://openebs.io/blog/](https://openebs.io/blog/). 
 
 
+## Mailing list
+
+Join our OpenEBS CNCF Mailing lists
+
+- For OpenEBS project updates, subscribe to [OpenEBS Announcements](https://lists.cncf.io/g/cncf-openebs-announcements)
+- For interacting with other OpenEBS users, subscribe to [OpenEBS Users](https://lists.cncf.io/g/cncf-openebs-users)
+
+## Community Meetings
+
+Join our weekly or monthly [community meetings](https://github.com/openebs/openebs/tree/master/community#community-meetings).
 
 <br>
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ sidebar_label: Troubleshooting
 
 **Steps for troubleshooting:**
 
-- Join <a href="https://openebs.org/community" target="_blank">Slack OpenEBS Community</a>
+- Contact <a href="/docs/next/support.html" target="_blank">OpenEBS Support</a>.
 - Search for similar issues added in this troubleshootiung section.
 - Search for any reported issues on <a href=" https://stackoverflow.com/questions/tagged/openebs" target="_blank">StackOverflow under OpenEBS tag</a>
 
@@ -1138,7 +1138,7 @@ Check the status of corresponding cStor volume using the following command:
 kubectl get cstorvolume -n <openebs_installed_namespace> -l openebs.io/persistent-volume=<PV_NAME>
 ```
 
-If cStor volume exists in `Healthy` or `Degraded` state then restarting of the application pod alone will bring back cStor volume to `RW` mode. If cStor volume exists in `Offline`, reach out to <a href="https://openebs.org/community" target="_blank">Slack OpenEBS Community</a> for assistance. 
+If cStor volume exists in `Healthy` or `Degraded` state then restarting of the application pod alone will bring back cStor volume to `RW` mode. If cStor volume exists in `Offline`, reach out to <a href="/docs/next/support.html" target="_blank">Slack OpenEBS Community</a> for assistance. 
 
 <hr>
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ sidebar_label: Troubleshooting
 
 **Steps for troubleshooting:**
 
-- Contact <a href="/docs/next/support.html" target="_blank">OpenEBS Support</a>.
+- Contact <a href="/docs/next/support.html" target="_blank">OpenEBS Community</a> for support.
 - Search for similar issues added in this troubleshootiung section.
 - Search for any reported issues on <a href=" https://stackoverflow.com/questions/tagged/openebs" target="_blank">StackOverflow under OpenEBS tag</a>
 
@@ -1138,7 +1138,7 @@ Check the status of corresponding cStor volume using the following command:
 kubectl get cstorvolume -n <openebs_installed_namespace> -l openebs.io/persistent-volume=<PV_NAME>
 ```
 
-If cStor volume exists in `Healthy` or `Degraded` state then restarting of the application pod alone will bring back cStor volume to `RW` mode. If cStor volume exists in `Offline`, reach out to <a href="/docs/next/support.html" target="_blank">Slack OpenEBS Community</a> for assistance. 
+If cStor volume exists in `Healthy` or `Degraded` state then restarting of the application pod alone will bring back cStor volume to `RW` mode. If cStor volume exists in `Offline`, reach out to <a href="/docs/next/support.html" target="_blank">OpenEBS Community</a> for assistance. 
 
 <hr>
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -7,7 +7,7 @@ sidebar_label: Upgrade
 
 Latest stable version of OpenEBS is 1.10.0. Check the release notes [here](https://github.com/openebs/openebs/releases/tag/v1.10.0).  Upgrade to the latest OpenEBS 1.9.0 version is supported only from 1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0 and the steps for upgrading from these versions can be found [here](https://github.com/openebs/openebs/blob/master/k8s/upgrades/README.md).
 
-Note: If you are upgrading Jiva volumes that are running in version 1.6 and 1.7, you must use these [pre-upgrade steps](https://github.com/openebs/charts/tree/master/scripts/jiva-tools) to check if your jiva volumes are impacted by [#2956](https://github.com/openebs/openebs/issues/2956). If they are, please reach out to us on [OpenEBS Slack] (https://openebs-community.slack.com/messages/openebs-users/)  or [Kubernetes Slack #openebs channel](https://kubernetes.slack.com/messages/openebs/) for helping you with the upgrade.
+Note: If you are upgrading Jiva volumes that are running in version 1.6 and 1.7, you must use these [pre-upgrade steps](https://github.com/openebs/charts/tree/master/scripts/jiva-tools) to check if your jiva volumes are impacted by [#2956](https://github.com/openebs/openebs/issues/2956). If they are, please reach out to us on [OpenEBS Slack channels](/docs/next/support.html) for helping you with the upgrade.
 
 
 ## Supported upgrade paths

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -7,7 +7,7 @@ sidebar_label: Upgrade
 
 Latest stable version of OpenEBS is 1.10.0. Check the release notes [here](https://github.com/openebs/openebs/releases/tag/v1.10.0).  Upgrade to the latest OpenEBS 1.9.0 version is supported only from 1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0 and the steps for upgrading from these versions can be found [here](https://github.com/openebs/openebs/blob/master/k8s/upgrades/README.md).
 
-Note: If you are upgrading Jiva volumes that are running in version 1.6 and 1.7, you must use these [pre-upgrade steps](https://github.com/openebs/charts/tree/master/scripts/jiva-tools) to check if your jiva volumes are impacted by [#2956](https://github.com/openebs/openebs/issues/2956). If they are, please reach out to us on [OpenEBS Slack channels](/docs/next/support.html) for helping you with the upgrade.
+Note: If you are upgrading Jiva volumes that are running in version 1.6 and 1.7, you must use these [pre-upgrade steps](https://github.com/openebs/charts/tree/master/scripts/jiva-tools) to check if your jiva volumes are impacted by [#2956](https://github.com/openebs/openebs/issues/2956). If they are, please reach out to [OpenEBS Community](/docs/next/support.html) for helping you with the upgrade.
 
 
 ## Supported upgrade paths

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -53,23 +53,7 @@ class Footer extends React.Component {
             </a>
             </div>
 	  <div>
-		<a href="https://openebs.io/join-our-slack-community" target="_blank">Get in touch with OpenEBS community via Slack</a>
-          </div>
-          </div>
-          <div>
-           <br />
-           <div>
-             <a href="https://mayadata.io" target="_blank">
-             <img
-                src={`${this.props.config.baseUrl}docs/assets/mayadata-primary.svg`}
-                alt="mayadata.io"
-                width="130"
-                height="110"
-              />
-            </a>
-            </div>
-	  <div>
-		<a href="https://director.mayadata.io" target="_blank">Get OpenEBS support through Director Online</a>
+		<a href="/docs/next/support.html" target="_blank">Get in touch with OpenEBS community</a>
           </div>
           </div>
         </section>

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -101,6 +101,12 @@ footer .sitemap .nav-home {
   transition: initial;
 }
 
+footer .sitemap a {
+  justify-content: center;
+  align-content: center;
+  display: flex;
+}
+
 /* NAV bar */
 
 .fixedHeaderContainer header img#logo {


### PR DESCRIPTION
The current openebs slack channel https://openebs-community.slack.com/messages/ isn't a sponsored channel. This PR updates the links to OpenEBS channels on the sponsored  K8s and CNCF slack. 

Signed-off-by: kmova <kiran.mova@mayadata.io>