### PR TITLE
fix(localpv): note to avoid nodeName in podspec

### DIFF
--- a/docs/uglocalpv-device.md
+++ b/docs/uglocalpv-device.md
@@ -275,6 +275,10 @@ By default, Local PV volume will be provisioned with volumeMode as filesystem. I
          name: local-storage
    ```
 
+   :::note 
+   As the Local PV storage classes use `waitForFirstConsumer`, do not use `nodeName` in the Pod spec to specify node affinity. If `nodeName` is used in the Pod spec, then PVC will remain in pending state. For more details refer https://github.com/openebs/openebs/issues/2915.
+   :::
+
 2. Create the Pod:
 
    ```

--- a/docs/uglocalpv-device.md
+++ b/docs/uglocalpv-device.md
@@ -276,7 +276,7 @@ By default, Local PV volume will be provisioned with volumeMode as filesystem. I
    ```
 
    :::note 
-   As the Local PV storage classes use `waitForFirstConsumer`, do not use `nodeName` in the Pod spec to specify node affinity. If `nodeName` is used in the Pod spec, then PVC will remain in pending state. For more details refer https://github.com/openebs/openebs/issues/2915.
+   As the Local PV storage classes use `waitForFirstConsumer`, do not use `nodeName` in the Pod spec to specify node affinity. If `nodeName` is used in the Pod spec, then PVC will remain in `pending` state. For more details refer https://github.com/openebs/openebs/issues/2915.
    :::
 
 2. Create the Pod:

--- a/docs/uglocalpv-hostpath.md
+++ b/docs/uglocalpv-hostpath.md
@@ -258,7 +258,7 @@ The next step is to create a PersistentVolumeClaim. Pods will use PersistentVolu
    ```
 
    :::note
-   As the Local PV storage classes use `waitForFirstConsumer`, do not use `nodeName` in the Pod spec to specify node affinity. If `nodeName` is used in the Pod spec, then PVC will remain in pending state. For more details refer https://github.com/openebs/openebs/issues/2915.
+   As the Local PV storage classes use `waitForFirstConsumer`, do not use `nodeName` in the Pod spec to specify node affinity. If `nodeName` is used in the Pod spec, then PVC will remain in `pending` state. For more details refer https://github.com/openebs/openebs/issues/2915.
    :::
 
 2. Create the Pod:

--- a/docs/uglocalpv-hostpath.md
+++ b/docs/uglocalpv-hostpath.md
@@ -257,6 +257,10 @@ The next step is to create a PersistentVolumeClaim. Pods will use PersistentVolu
          name: local-storage
    ```
 
+   :::note
+   As the Local PV storage classes use `waitForFirstConsumer`, do not use `nodeName` in the Pod spec to specify node affinity. If `nodeName` is used in the Pod spec, then PVC will remain in pending state. For more details refer https://github.com/openebs/openebs/issues/2915.
+   :::
+
 2. Create the Pod:
 
    ```


### PR DESCRIPTION
Fixes https://github.com/openebs/openebs/issues/2915

Using `nodeName` in Pod spec results in scheduler skipping
the step of assigning a node to Pod and inturn not setting
the node details on PVC. This will result in PVC being stuck
in pending state, when `waitForFirstconsumer` is specified
in the corresponding Storage Class.

This commit adds a note to docs to avoid specifying nodeName
in pod spec.

Signed-off-by: kmova <kiran.mova@mayadata.io>