### PR TITLE
"Set cluster-admin user context and RBAC" doesn't really tell fix

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,7 +43,7 @@ iSCSI client is a pre-requisite for provisioning cStor and Jiva volumes. However
 
 
 
-## Set cluster-admin user context and RBAC
+## Set cluster-admin user context
 
 <br>
 


### PR DESCRIPTION
Issue #3120 "Set cluster-admin user context and RBAC" doesn't really tell. 