### PR TITLE
build(travis): fix node version to 14.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-node_js: stable
+node_js:
+  - 14
 env:
   global:
    - COMMIT=${TRAVIS_COMMIT::6}


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@mayadata.io>

The latest version of node selected by travis (15.x) is not compatible with the other packages. The following error was thrown with latest node.js. 

```
/home/travis/build/openebs/openebs-docs/website/node_modules/docusaurus/lib/pages/en/tempversions.js:166
                versions.map(function (version) {
                         ^
TypeError: versions.map is not a function
```