### PR TITLE
fix(overview): update quick start links and intro

### DIFF
--- a/docs/alphafeatures.md
+++ b/docs/alphafeatures.md
@@ -10,26 +10,11 @@ sidebar_label: Alpha Features
 This page provides an overview of OpenEBS components and features presently in Alpha version and under active development. These features are not recommended to be used in production. We suggest you to familiarize and try these features on test clusters and reach out to [OpenEBS Community](/docs/next/support.html) if you have any queries, feedback or need help on these features.
 
 The list of alpha features include:
-- [Mayastor](#mayastor)
 - [Dynamic Local PV - Rawfile](#dynamic-local-pv-rawfile)
 
   :::note
   Upgrade is not supported for features in Alpha version.
   :::
-
-
-## Mayastor
-
-OpenEBS Mayastor developed using NVMe based architecture, targeted at addressing performance requirements of IO-intensive workloads is ready for alpha testing. For detailed instructions on how to get started with Mayastor please refer this [Quick-start guide](https://mayastor.gitbook.io/introduction/).
-
-The following features are supported:
-- Creation of a Mayastor pool using block device attached to the node or by direct connection to existing iSCSI or NVMe-oF exports.
-- CSI driver for managing Mayastor Volumes.
-- Support for accessing the Mayastor Volumes using iSCSI and NVMe-oF TCP
-- Kubernetes Custom Resources for Mayastor Pool and Volumes, and Mayastor Storage Volume” (MSV) showing the status of the Volume.
-- Support for Prometheus metrics and sample Grafana dashboard
-- Workload protection via n-way synchronous replication (experimental)
-- Shown to deliver significantly greater performance than Jiva and cStor engines
 
 ## Dynamic Local PV - Rawfile
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,90 +5,78 @@ sidebar_label: Overview
 ---
 ------
 
-## Introduction ##
+## Introduction 
 
-OpenEBS is the leading open-source project for container-attached and
-container-native storage on Kubernetes. OpenEBS adopts
-Container Attached Storage (CAS) approach, where each workload is
-provided with a dedicated storage controller.
-OpenEBS implements granular storage policies and isolation that enable users
-to optimize storage for each specific workload. OpenEBS is built 
-completely in userspace making it highly portable to run across any OS/platform.
+**OpenEBS** is the most widely deployed and easy to use open-source storage solution for Kubernetes.
 
-OpenEBS is a collection Storage Engines, allowing you to pick the right 
-storage solution for your Stateful workloads and the type of Kubernetes platform. 
+**OpenEBS** is the leading open-source example of a category of cloud native storage solutions sometimes called [Container Attached Storage](https://www.cncf.io/blog/2020/09/22/container-attached-storage-is-cloud-native-storage-cas/). **OpenEBS** is listed as an open-source example in the [CNCF Storage Landscape White Paper](https://github.com/cncf/sig-storage/blob/master/CNCF%20Storage%20Landscape%20-%20White%20Paper.pdf) under the hyperconverged storage solutions.
 
-See OpenEBS  <a href="/docs/next/features.html">Features & Benefits</a>
-and <a href="https://github.com/openebs/openebs/blob/master/ADOPTERS.md" target="_blank">OpenEBS Adoption stories</a>.
+Some key aspects that make OpenEBS different compared to other traditional storage solutions:
+- Built using the _micro-services architecture_ like the applications it serves. OpenEBS is itself deployed as a set of containers on Kubernetes worker nodes. Uses Kubernetes itself to orchestrate and manage OpenEBS components.
+- Built completely in userspace making it highly portable to run across _any OS/platform_.
+- Completely intent-driven, inheriting the same principles that drive the _ease of use_ with Kubernetes.
+- OpenEBS supports a range of storage engines so that developers can deploy the storage technology appropriate to their application design objectives. Distributed applications like Cassandra can use the _LocalPV_ engine for lowest latency writes. Monolithic applications like MySQL and PostgreSQL can use _Mayastor_ or _cStor based on ZFS_ for resilience. Streaming applications like Kafka can use the NVMe engine [Mayastor](https://github.com/openebs/Mayastor) for best performance in edge environments. Across engine types, OpenEBS provides a consistent framework for high availability, snapshots, clones and manageability.
 
+An added advantage of being a completely Kubernetes native solution is that administrators and developers can interact and manage OpenEBS using all the wonderful tooling that is available for Kubernetes like kubectl, Helm, Prometheus, Grafana, Weave Scope, etc.
+
+Check out what users of OpenEBS have to say about their experience in <a href="https://github.com/openebs/openebs/blob/master/ADOPTERS.md" target="_blank">OpenEBS Adoption stories</a>.
+
+## Types of OpenEBS Storage Engines
+
+OpenEBS is a collection Storage Engines, allowing you to pick the right storage solution for your Stateful workloads and the type of Kubernetes platform.  At a high-level, OpenEBS supports two broad categories of volumes - Local and Replicated. 
+
+### Local Volumes 
+
+Local Volumes are accessible only from a single node in the cluster. Pods using Local Volume have to be scheduled on the node where volume is provisioned. Local Volumes are typically preferred for distributed workloads like Cassandra, MongoDB, Elastic, etc that are distributed in nature and have high availability built into them. 
+
+Depending on the type of storage attached to your Kubernetes worker nodes, you can select from different flavors of Dynamic Local PV - Hostpath, Device, ZFS or Rawfile.
+
+### Replicated Volumes (aka Highly Available Volumes)
+
+Replicated Volumes as the name suggests, are those that have their data synchronously replicated to multiple nodes. Volumes can sustain node failures.  The replication also can be setup across availability zones helping applications move across availability zones. 
+
+Replicated Volumes also are capable of enterprise storage features like snapshots, clone, volume expansion and so forth. Replicated Volumes are a preferred choice for Stateful workloads like Percona/MySQL, Jira, GitLab, etc. 
+
+Depending on the type of storage attached to your Kubernetes worker nodes and application performance requirements, you can select from Jiva, cStor or Mayastor. 
+
+### Selecting the right storage engine
+
+See the following table for recommendation on which engine is right for your application depending on the application requirements and storage available on your Kubernetes nodes. 
+
+| Application requirements   | Storage Type | OpenEBS Volumes
+|--- |--- |--- 
+| Low Latency, High Availability, Synchronous replication, Snapshots, Clones, Thin provisioning | SSDs/Cloud Volumes | <a href="https://mayastor.gitbook.io/introduction/" target="_blank">OpenEBS Mayastor</a>
+| High Availability, Synchronous replication, Snapshots, Clones, Thin provisioning | Disks/SSDs/Cloud Volumes | <a href="https://github.com/openebs/cstor-operators" target="_blank">OpenEBS cStor</a>
+| High Availability, Synchronous replication, Thin provisioning | hostpath or external mounted storage | [OpenEBS Jiva](/docs/next/jivaguide.html)
+| Low latency, Local PV | hostpath or external mounted storage | [Dynamic Local PV - Hostpath](/docs/next/uglocalpv-hostpath.html)
+| Low latency, Local PV | Disks/SSDs/Cloud Volumes | [Dynamic Local PV - Device](/docs/next/uglocalpv-device.html)
+| Low latency, Local PV, Snapshots, Clones | Disks/SSDs/Cloud Volumes | <a href="https://github.com/openebs/zfs-localpv" target="_blank">OpenEBS Dynamic Local PV - ZFS </a>
+
+OpenEBS is also developing <a href="https://github.com/openebs/rawfile-localpv" target="_blank">Dynamic Local PV - Rawfile</a> storage engines available for alpha testing.
+
+OpenEBS has a vibrant community that can help you get started. If you have further question and want to learn more about OpenEBS, please join [OpenEBS community on Kubernetes Slack](https://kubernetes.slack.com). If you are already signed up, head to our discussions at [#openebs](https://kubernetes.slack.com/messages/openebs/) channel. 
 
 <br>
 
 ## Quickstart
 
-- When using synchronous replication, iSCSI is used to attach storage from OpenEBS to 
-  application pods. Hence OpenEBS requires iSCSI client to be configured and `iscsid` service
-  running on the worker nodes.
-  Verify if [iSCSI service is up](/docs/next/prerequisites.html) and
-  running before starting the installation.
+Installing OpenEBS in your cluster is as simple as a few `kubectl` or `helm` commands depending on the storage engine. Here are the list of our Quickstart guides with detailed instructions for each storage engine.
 
-- Default installation works in most of the cases. As a *Kubernetes cluster-admin*, start the default installation using either
+### Local Volumes
 
-  ```
-  helm repo add openebs https://openebs.github.io/charts
-  helm repo update
-  helm install --namespace openebs --name openebs openebs/openebs
-  ```
-  More information about OpenEBS installation using different Helm versions can be found [here](/docs/next/installation.html#installation-through-helm).
+- [Local PV hostpath](/docs/next/uglocalpv-hostpath.html)
+- [Local PV device](/docs/next/uglocalpv-device.html)
+- [ZFS Local PV](https://github.com/openebs/zfs-localpv)
+- [Rawfile Local PV (alpha)](https://github.com/openebs/rawfile-localpv)
 
-  (or)
+### Replicated Volumes
 
-  ```
-  kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
-  ```
-  
-  For advanced installation steps, see [Installation](/docs/next/installation.html) section.
+- [cStor](https://github.com/openebs/cstor-operators/blob/master/docs/quick.md)
+- [Jiva](/docs/next/installation.html)
+- [Mayastor](https://mayastor.gitbook.io/introduction/)
 
-- [Verify if OpenEBS is installed successfully](/docs/next/installation.html#verifying-openebs-installation)
-  and start provisioning OpenEBS volumes through Kubernetes PVC
-  interface by using `kubectl` command. 
 
 <br>
-
-## OpenEBS Storage Engines
-
-OpenEBS is a Kubernetes native hyperconverged storage solution. 
-OpenEBS consumes the storage (disks, SSDs, cloud volumes, etc) available 
-on the Kubernetes worker nodes to dynamically provision Kubernetes 
-Persistent Volumes. 
-
-OpenEBS can provision different type of Local PV for Stateful Workloads 
-like Cassandra, MongoDB, Elastic, etc that are distributed in nature and 
-have high availiability built into them. 
-Depending on the type of storage attached to your Kubernetes worker nodes, 
-you can select from Dynamic Local PV - Hostpath, Device, ZFS or Rawfile.
-
-OpenEBS can provision Persistent Volumes with features like synchronous replication, 
-snapshots and clones, backup and restore that can be used with Stateful workloads
-like Percona/MySQL, Jira, GitLab, etc. The replication also can be setup to be 
-across Kubernetes zones resulting in high availability for cross AZ setups. 
-Depending on the type of storage attached to your Kubernetes worker nodes and 
-application performance requirements, you can select from Jiva, cStor or Mayastor. 
-
-See the following table for recommendation on which engine is right for 
-you depending on the type of your application requirements and 
-storage available on your Kubernetes nodes. 
-
-| Application requirements   | Storage | OpenEBS Volumes
-|--- |--- |--- 
-| Protect against node failures, Synchronous replication, Snapshots, Clones, Thin provisioning | Use Disks/SSDs/Cloud Volumes | <a href="https://github.com/openebs/cstor-operators" target="_blank">OpenEBS cStor</a>
-| Protect against node failures, Synchronous replication, Thin provisioning | Use hostpath or external mounted storage | [OpenEBS Jiva](/docs/next/jivaguide.html)
-| Low latency, Local PV | Use hostpath or external mounted storage | [Dynamic Local PV - Hostpath](/docs/next/uglocalpv-hostpath.html)
-| Low latency, Local PV | Use Disks/SSDs/Cloud Volumes | [Dynamic Local PV - Device](/docs/next/uglocalpv-device.html)
-| Low latency, Local PV, Snapshots, Clones | Use Disks/SSDs/Cloud Volumes | <a href="https://github.com/openebs/zfs-localpv" target="_blank">OpenEBS Dynamic Local PV - ZFS </a>
-
-OpenEBS is also developing <a href="https://github.com/openebs/Mayastor" target="_blank">Mayastor</a> and <a href="https://github.com/openebs/rawfile-localpv" target="_blank">Dynamic Local PV - Rawfile</a> storage engines available for alpha testing.
-
 
 ## Explore documentation
 
@@ -210,7 +198,7 @@ OpenEBS is also developing <a href="https://github.com/openebs/Mayastor" target=
 
 ### [Container Attached Storage (CAS)](/docs/next/cas.html)
 
-### <a href="https://www.cncf.io/blog/2018/04/19/container-attached-storage-a-primer/" target="_blank">CNCF CAS Blog </a>
+### <a href="https://www.cncf.io/blog/2020/09/22/container-attached-storage-is-cloud-native-storage-cas/" target="_blank">CNCF CAS Blog </a>
 
 ### [OpenEBS architecture](/docs/next/architecture.html)
 


### PR DESCRIPTION
The OpenEBS install is under-going refactoring to make
each engine installed separately. Updated the quick
start links for different engines.

Also removed Mayastor from alpha stage.

Signed-off-by: kmova <kiran.mova@mayadata.io>