### PR TITLE
added Gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,18 @@
+ports:
+  - port: 3000
+    visibility: public  
+    onOpen: open-preview
+tasks:
+  - before: cd website
+    init: npm install
+    command: npm start
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: false
+    addCheck: true
+    addComment: true
+    addBadge: false
+    addLabel: false

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@
 [![Commit Activity (Year)](https://img.shields.io/github/commit-activity/y/openebs/openebs-docs.svg?style=flat-square)](https://github.com/openebs/openebs-docs/commits)
 [![Contributors](https://img.shields.io/github/contributors/openebs/openebs-docs.svg?style=flat-square)](https://github.com/openebs/openebs-docs/graphs/contributors)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fopenebs%2Fopenebs-docs.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fopenebs%2Fopenebs-docs?ref=badge_shield)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/openebs/openebs-docs)
 
 openebs-docs is the repository for the official OpenEBS documentation. This is using Docusaurus as a documentation framework. It's easy to use and write documentation using Docusaurus, which uses markdown markup language.
 Additional details on the Docusaurus project can be found [here](https://docusaurus.io/docs/en/installation.html).
 
 ## For Developers
+
+Instead of performing the following steps, you might just want to edit the docs in a fully pre-configured development environment 
+in the browser: [![Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://github.com/openebs/openebs-docs).
 
 ### Install Node.js
 
@@ -67,3 +71,4 @@ The following procedure lists the tasks from the time you select an issue to pub
 The project is licensed under the Apache 2.0 License. See [LICENSE](LICENSE) for the full license text. 
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fopenebs%2Fopenebs-docs.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fopenebs%2Fopenebs-docs?ref=badge_large)
+


### PR DESCRIPTION
Hi OpenEBS-crew,

here is a PR that fully automates the dev setup of the OpenEBS documentation with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/openebs/openebs-docs/pull/929)

<img width="1601" alt="Screen Shot 2021-05-03 at 14 44 32" src="https://user-images.githubusercontent.com/377752/116890510-fe024700-ac2d-11eb-93bf-214f52d81b79.png">

## What it does
- automates all setup steps described in the README, e.g. setup `node`,  `yarn` and `npm`
- run the `npm install` ahead-of-time (so you don't need to wait)
- starts `docusaurus` and a preview browser that enables a fast turnarounds.
- gives anyone immediate access to a VS Code IDE in that environment with a single click

I hope this can make life easier for contributors, and for maintainers who need to review many PRs (hint: you can already open this PR in Gitpod to easily review & test it without messing up your local checkout).

ps. I'm looking forward to your feedback on this PR! 🚀
pps. You could also stop checking in the `node_modules` and use a newer version of `docusaurus` that enables auto reload of the browser. The latter, unfortunately, is a bit more involving as they have changed they way they handle versions.

Signed-off-by: Jan Koehnlein <jan@gitpod.io>